### PR TITLE
[neighbour-mac-noptf] use a newly added address and neighbour on a routing interface

### DIFF
--- a/ansible/library/show_interface.py
+++ b/ansible/library/show_interface.py
@@ -82,7 +82,7 @@ class ShowInterfaceModule(object):
         self.module.exit_json(ansible_facts=self.facts)
 
     def collect_interface_status(self):
-        regex_int = re.compile(r'(\S+)\s+[\d,N\/A]+\s+(\w+)\s+(\d+)\s+([\w\/]+)\s+(\w+)\s+(\w+)\s+(\w+)')
+        regex_int = re.compile(r'(\S+)\s+[\d,]+\s+(\w+)\s+(\d+)\s+([\w\/]+)\s+(\w+)\s+(\w+)')
         self.int_status = {}
         if self.m_args['interfaces'] is not None:
             for interface in self.m_args['interfaces']:
@@ -96,9 +96,8 @@ class ShowInterfaceModule(object):
                             self.int_status[interface]['name'] = regex_int.match(line).group(1)
                             self.int_status[interface]['speed'] = regex_int.match(line).group(2)
                             self.int_status[interface]['alias'] = regex_int.match(line).group(4)
-                            self.int_status[interface]['vlan'] = regex_int.match(line).group(5)
-                            self.int_status[interface]['oper_state'] = regex_int.match(line).group(6)
-                            self.int_status[interface]['admin_state'] = regex_int.match(line).group(7)
+                            self.int_status[interface]['oper_state'] = regex_int.match(line).group(5)
+                            self.int_status[interface]['admin_state'] = regex_int.match(line).group(6)
                     self.facts['int_status'] = self.int_status
                 except Exception as e:
                     self.module.fail_json(msg=str(e))
@@ -115,9 +114,8 @@ class ShowInterfaceModule(object):
                         self.int_status[interface]['name'] = interface
                         self.int_status[interface]['speed'] = regex_int.match(line).group(2)
                         self.int_status[interface]['alias'] = regex_int.match(line).group(4)
-                        self.int_status[interface]['vlan'] = regex_int.match(line).group(5)
-                        self.int_status[interface]['oper_state'] = regex_int.match(line).group(6)
-                        self.int_status[interface]['admin_state'] = regex_int.match(line).group(7)
+                        self.int_status[interface]['oper_state'] = regex_int.match(line).group(5)
+                        self.int_status[interface]['admin_state'] = regex_int.match(line).group(6)
                 self.facts['int_status'] = self.int_status
             except Exception as e:
                 self.module.fail_json(msg=str(e))

--- a/ansible/library/show_interface.py
+++ b/ansible/library/show_interface.py
@@ -82,7 +82,7 @@ class ShowInterfaceModule(object):
         self.module.exit_json(ansible_facts=self.facts)
 
     def collect_interface_status(self):
-        regex_int = re.compile(r'(\S+)\s+[\d,]+\s+(\w+)\s+(\d+)\s+([\w\/]+)\s+(\w+)\s+(\w+)')
+        regex_int = re.compile(r'(\S+)\s+[\d,N\/A]+\s+(\w+)\s+(\d+)\s+([\w\/]+)\s+(\w+)\s+(\w+)\s+(\w+)')
         self.int_status = {}
         if self.m_args['interfaces'] is not None:
             for interface in self.m_args['interfaces']:
@@ -96,8 +96,9 @@ class ShowInterfaceModule(object):
                             self.int_status[interface]['name'] = regex_int.match(line).group(1)
                             self.int_status[interface]['speed'] = regex_int.match(line).group(2)
                             self.int_status[interface]['alias'] = regex_int.match(line).group(4)
-                            self.int_status[interface]['oper_state'] = regex_int.match(line).group(5)
-                            self.int_status[interface]['admin_state'] = regex_int.match(line).group(6)
+                            self.int_status[interface]['vlan'] = regex_int.match(line).group(5)
+                            self.int_status[interface]['oper_state'] = regex_int.match(line).group(6)
+                            self.int_status[interface]['admin_state'] = regex_int.match(line).group(7)
                     self.facts['int_status'] = self.int_status
                 except Exception as e:
                     self.module.fail_json(msg=str(e))
@@ -114,8 +115,9 @@ class ShowInterfaceModule(object):
                         self.int_status[interface]['name'] = interface
                         self.int_status[interface]['speed'] = regex_int.match(line).group(2)
                         self.int_status[interface]['alias'] = regex_int.match(line).group(4)
-                        self.int_status[interface]['oper_state'] = regex_int.match(line).group(5)
-                        self.int_status[interface]['admin_state'] = regex_int.match(line).group(6)
+                        self.int_status[interface]['vlan'] = regex_int.match(line).group(5)
+                        self.int_status[interface]['oper_state'] = regex_int.match(line).group(6)
+                        self.int_status[interface]['admin_state'] = regex_int.match(line).group(7)
                 self.facts['int_status'] = self.int_status
             except Exception as e:
                 self.module.fail_json(msg=str(e))

--- a/ansible/roles/test/tasks/neighbour-mac-noptf.yml
+++ b/ansible/roles/test/tasks/neighbour-mac-noptf.yml
@@ -31,16 +31,19 @@
   - name: init loganalyzer for later syslog analysis
     include: roles/test/files/tools/loganalyzer/loganalyzer_init.yml
 
-  - name: gather DUT interface table
-    show_interface: command='status'
-
-  - name: select A routing interface for testing
+  - name: select Ethernet0 for testing on t1 and t0
     set_fact:
-      routing_interface: "{{ item.key }}"
-    with_dict: "{{int_status}}"
-    when:
-      - ('routed' in item.value['vlan'] and 'up' in item.value['oper_state'])
-      - int_status | length != 0
+      routing_interface: "Ethernet0"
+    when: testbed_type in ['t1', 't0']
+
+  - name: Startup {{routing_interface}} for t0
+    command: "config interface startup {{routing_interface}}"
+    when: testbed_type in ['t0']
+
+  - name: select PortChannel0002 for testing on t1-lag
+    set_fact:
+      routing_interface: "PortChannel0002"
+    when: testbed_type in ['t1-lag']
 
   ########## Test V4 mac address change #################
   - name: pick {{routing_interface}} to test change mac behavior

--- a/ansible/roles/test/tasks/neighbour-mac-noptf.yml
+++ b/ansible/roles/test/tasks/neighbour-mac-noptf.yml
@@ -34,7 +34,7 @@
   - name: gather DUT interface table
     show_interface: command='status'
 
-  - name: select A routing interface for futher use
+  - name: select A routing interface for testing
     set_fact:
       routing_interface: "{{ item.key }}"
     with_dict: "{{int_status}}"
@@ -42,35 +42,23 @@
       - ('routed' in item.value['vlan'])
       - int_status | length != 0
 
-  - name: gather DUT arp table
-    switch_arptable:
-
   ########## Test V4 mac address change #################
-  - name: pick IPv4 neighbor to test change mac behavior
-    set_fact:
-      v4_nei: "{{ item.key }}"
-      v4_intf: "{{ item.value['interface'] }}"
-    with_dict: "{{ arptable.v4 }}"
-    when:
-      - ('Ethernet' in item.value['interface']) or ('PortChannel' in item.value['interface'])
-      - arptable.v4 | length != 0
-
-  - name: make use of {{routing_interface}} if no ipv4 neighbor was found for testing
+  - name: pick {{routing_interface}} to test change mac behavior
     set_fact:
       v4_intf: "{{routing_interface}}"
       v4_nei: "{{ v4_intf_nei }}"
       need_add_ip: True
     when: v4_nei is not defined
 
-  - name: startup {{routing_interface}}
+  - name: startup {{v4_intf}}
     command: "config interface startup {{ v4_intf }}"
     when: need_add_ip is defined and need_add_ip == True
 
-  - name: add an ip entry for {{routing_interface}}
+  - name: add an ip entry for {{v4_intf}}
     command: "config interface ip add {{ v4_intf }} {{ v4_intf_ip }}"
     when: need_add_ip is defined and need_add_ip == True
 
-  - name: add neighbor of {{routing_interface}}
+  - name: add neighbor for {{v4_intf}}
     command: "/sbin/ip neigh add {{ v4_intf_nei }} lladdr {{ v4_mac1 }} dev {{ v4_intf }}"
     when: need_add_ip is defined and need_add_ip == True
 
@@ -107,33 +95,23 @@
   - assert: { that: "neighbour_mac.stdout | lower == v4_mac2" }
 
   ############## Test V6 mac change   ##################
-  - name: pick IPv6 neighbor to test change mac address"
-    set_fact:
-      v6_nei: "{{ item.key }}"
-      v6_intf: "{{ item.value['interface'] }}"
-    with_dict: "{{ arptable.v6 }}"
-    when:
-       - "'fe80::' not in  item.key | lower"
-       - ('Ethernet' in item.value['interface']) or ('PortChannel' in item.value['interface'])
-       - arptable.v6 | length != 0
-
-  - name: pick {{routing_interface}} as test interface if no ipv6 neighbor was found for testing
+  - name: pick {{routing_interface}} as test interface
     set_fact:
       v6_intf: "{{routing_interface}}"
       v6_nei: "{{ v6_intf_nei }}"
       need_add_ipv6: True
     when: v6_nei is not defined
 
-  - name: startup {{routing_interface}}
-    command: "config interface startup {{routing_interface}}"
+  - name: startup {{v6_intf}}
+    command: "config interface startup {{v6_intf}}"
     when: need_add_ipv6 is defined and need_add_ipv6 == True
 
-  - name: add an ipv6 entry for {{routing_interface}}
-    command: "config interface ip add {{routing_interface}} {{ v6_intf_ip }}"
+  - name: add an ipv6 entry for {{v6_intf}}
+    command: "config interface ip add {{v6_intf}} {{ v6_intf_ip }}"
     when: need_add_ipv6 is defined and need_add_ipv6 == True
 
-  - name: add an ipv6 neighbor for {{routing_interface}}
-    command: "/sbin/ip neigh add {{ v6_intf_nei }} lladdr {{ v6_mac1 }} dev {{routing_interface}}"
+  - name: add an ipv6 neighbor for {{v6_intf}}
+    command: "/sbin/ip neigh add {{ v6_intf_nei }} lladdr {{ v6_mac1 }} dev {{v6_intf}}"
     when: need_add_ipv6 is defined and need_add_ipv6 == True
 
   - name: change v6 neighbor mac address 1st time

--- a/ansible/roles/test/tasks/neighbour-mac-noptf.yml
+++ b/ansible/roles/test/tasks/neighbour-mac-noptf.yml
@@ -31,6 +31,17 @@
   - name: init loganalyzer for later syslog analysis
     include: roles/test/files/tools/loganalyzer/loganalyzer_init.yml
 
+  - name: gather DUT interface table
+    show_interface: command='status'
+
+  - name: select A routing interface for futher use
+    set_fact:
+      routing_interface: "{{ item.key }}"
+    with_dict: "{{int_status}}"
+    when:
+      - ('routed' in item.value['vlan'])
+      - int_status | length != 0
+
   - name: gather DUT arp table
     switch_arptable:
 
@@ -44,22 +55,24 @@
       - ('Ethernet' in item.value['interface']) or ('PortChannel' in item.value['interface'])
       - arptable.v4 | length != 0
 
-  - block:
-    - name: select Ethernet0 if cannot find a v4 neighbor for test
-      set_fact:
-        v4_intf: "Ethernet0"
-        v4_nei: "{{ v4_intf_nei }}"
-
-    - name: startup Ethernet0
-      command: "config interface startup Ethernet0"
-
-    - name: add an ip entry for Ethernet0
-      command: "config interface ip add Ethernet0 {{ v4_intf_ip }}"
-
-    - name: add neighbor of Ethernet0
-      command: "/sbin/ip neigh add {{ v4_intf_nei }} lladdr {{ v4_mac1 }} dev Ethernet0"
-
+  - name: make use of {{routing_interface}} if no ipv4 neighbor was found for testing
+    set_fact:
+      v4_intf: "{{routing_interface}}"
+      v4_nei: "{{ v4_intf_nei }}"
+      need_add_ip: True
     when: v4_nei is not defined
+
+  - name: startup {{routing_interface}}
+    command: "config interface startup {{ v4_intf }}"
+    when: need_add_ip is defined and need_add_ip == True
+
+  - name: add an ip entry for {{routing_interface}}
+    command: "config interface ip add {{ v4_intf }} {{ v4_intf_ip }}"
+    when: need_add_ip is defined and need_add_ip == True
+
+  - name: add neighbor of {{routing_interface}}
+    command: "/sbin/ip neigh add {{ v4_intf_nei }} lladdr {{ v4_mac1 }} dev {{ v4_intf }}"
+    when: need_add_ip is defined and need_add_ip == True
 
   - name: change v4 neighbor mac address 1st time
     command: "ip neigh change {{ v4_nei }} lladdr {{ v4_mac1 }} dev {{ v4_intf }}"
@@ -104,22 +117,24 @@
        - ('Ethernet' in item.value['interface']) or ('PortChannel' in item.value['interface'])
        - arptable.v6 | length != 0
 
-  - block:
-    - name: pick Ethernet0 as test interface if cannot find v6 neighbor to test
-      set_fact:
-        v6_intf: "Ethernet0"
-        v6_nei: "{{ v6_intf_nei }}"
-
-    - name: startup Ethernet0
-      command: "config interface startup Ethernet0"
-
-    - name: add an ipv6 entry for Ethernet0 if no v6 neighbor was found
-      command: "config interface ip add Ethernet0 {{ v6_intf_ip }}"
-
-    - name: add an ipv6 neighbor for Ethernet0 if no v6 neighbor was found
-      command: "/sbin/ip neigh add {{ v6_intf_nei }} lladdr {{ v6_mac1 }} dev Ethernet0"
-
+  - name: pick {{routing_interface}} as test interface if no ipv6 neighbor was found for testing
+    set_fact:
+      v6_intf: "{{routing_interface}}"
+      v6_nei: "{{ v6_intf_nei }}"
+      need_add_ipv6: True
     when: v6_nei is not defined
+
+  - name: startup {{routing_interface}}
+    command: "config interface startup {{routing_interface}}"
+    when: need_add_ipv6 is defined and need_add_ipv6 == True
+
+  - name: add an ipv6 entry for {{routing_interface}}
+    command: "config interface ip add {{routing_interface}} {{ v6_intf_ip }}"
+    when: need_add_ipv6 is defined and need_add_ipv6 == True
+
+  - name: add an ipv6 neighbor for {{routing_interface}}
+    command: "/sbin/ip neigh add {{ v6_intf_nei }} lladdr {{ v6_mac1 }} dev {{routing_interface}}"
+    when: need_add_ipv6 is defined and need_add_ipv6 == True
 
   - name: change v6 neighbor mac address 1st time
     command: "ip -6 neigh change {{ v6_nei }} lladdr {{ v6_mac1 }} dev {{ v6_intf }}"

--- a/ansible/roles/test/tasks/neighbour-mac-noptf.yml
+++ b/ansible/roles/test/tasks/neighbour-mac-noptf.yml
@@ -47,20 +47,15 @@
     set_fact:
       v4_intf: "{{routing_interface}}"
       v4_nei: "{{ v4_intf_nei }}"
-      need_add_ip: True
-    when: v4_nei is not defined
 
   - name: startup {{v4_intf}}
     command: "config interface startup {{ v4_intf }}"
-    when: need_add_ip is defined and need_add_ip == True
 
   - name: add an ip entry for {{v4_intf}}
     command: "config interface ip add {{ v4_intf }} {{ v4_intf_ip }}"
-    when: need_add_ip is defined and need_add_ip == True
 
   - name: add neighbor for {{v4_intf}}
     command: "/sbin/ip neigh add {{ v4_intf_nei }} lladdr {{ v4_mac1 }} dev {{ v4_intf }}"
-    when: need_add_ip is defined and need_add_ip == True
 
   - name: change v4 neighbor mac address 1st time
     command: "ip neigh change {{ v4_nei }} lladdr {{ v4_mac1 }} dev {{ v4_intf }}"
@@ -99,20 +94,15 @@
     set_fact:
       v6_intf: "{{routing_interface}}"
       v6_nei: "{{ v6_intf_nei }}"
-      need_add_ipv6: True
-    when: v6_nei is not defined
 
   - name: startup {{v6_intf}}
     command: "config interface startup {{v6_intf}}"
-    when: need_add_ipv6 is defined and need_add_ipv6 == True
 
   - name: add an ipv6 entry for {{v6_intf}}
     command: "config interface ip add {{v6_intf}} {{ v6_intf_ip }}"
-    when: need_add_ipv6 is defined and need_add_ipv6 == True
 
   - name: add an ipv6 neighbor for {{v6_intf}}
     command: "/sbin/ip neigh add {{ v6_intf_nei }} lladdr {{ v6_mac1 }} dev {{v6_intf}}"
-    when: need_add_ipv6 is defined and need_add_ipv6 == True
 
   - name: change v6 neighbor mac address 1st time
     command: "ip -6 neigh change {{ v6_nei }} lladdr {{ v6_mac1 }} dev {{ v6_intf }}"

--- a/ansible/roles/test/tasks/neighbour-mac-noptf.yml
+++ b/ansible/roles/test/tasks/neighbour-mac-noptf.yml
@@ -39,7 +39,7 @@
       routing_interface: "{{ item.key }}"
     with_dict: "{{int_status}}"
     when:
-      - ('routed' in item.value['vlan'])
+      - ('routed' in item.value['vlan'] and 'up' in item.value['oper_state'])
       - int_status | length != 0
 
   ########## Test V4 mac address change #################
@@ -47,9 +47,6 @@
     set_fact:
       v4_intf: "{{routing_interface}}"
       v4_nei: "{{ v4_intf_nei }}"
-
-  - name: startup {{v4_intf}}
-    command: "config interface startup {{ v4_intf }}"
 
   - name: add an ip entry for {{v4_intf}}
     command: "config interface ip add {{ v4_intf }} {{ v4_intf_ip }}"
@@ -94,9 +91,6 @@
     set_fact:
       v6_intf: "{{routing_interface}}"
       v6_nei: "{{ v6_intf_nei }}"
-
-  - name: startup {{v6_intf}}
-    command: "config interface startup {{v6_intf}}"
 
   - name: add an ipv6 entry for {{v6_intf}}
     command: "config interface ip add {{v6_intf}} {{ v6_intf_ip }}"


### PR DESCRIPTION
### Description of PR

Summary:
Do not test in a way where updating an existing arp entry's mac since those entries stand for BGP'neighbour and to update their mac address can cause BGP neighbour down and routing entries withdrew, which makes DUT busy and unable to handle arp's mac update in time, thus failing the test.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Currently, Neighbour-mac works in the following flow (take ipv4 as an example, ipv6 is similar):
1.	Select an existing ARP entry for the test.
2.	If it is unable to find one, it will use Ethernet0 for the test. An ip address and arp entry will be configured on it in order to do the test.
3.	Change the mac of arp entry twice.
4.	Check whether the arp’s mac update has been pushed to the SAI table.

we remove the step 1 and 2 with the following step:
select a routing interface from show interface status, add an ip address and an arp on it for the test.

#### How did you verify/test it?
do the test on topo t0, t1, t1-lag.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
