### PR TITLE
enhance the interface status and sfp modules checking in platform test

### DIFF
--- a/tests/platform/check_all_interface_info.py
+++ b/tests/platform/check_all_interface_info.py
@@ -1,0 +1,20 @@
+"""
+Helper script for checking all related information of interfaces
+
+This script contains re-usable functions for checking status of interfaces on SONiC.
+"""
+import logging
+from check_transceiver_status import all_transceivers_detected
+from check_interface_status import check_interface_status
+
+
+def check_interface_information(dut, interfaces):
+    if not all_transceivers_detected(dut, interfaces):
+        logging.info("Not all transceivers are detected")
+        return False
+    if not check_interface_status(dut, interfaces):
+        logging.info("Not all interfaces are up")
+        return False
+
+    return True
+

--- a/tests/platform/check_interface_status.py
+++ b/tests/platform/check_interface_status.py
@@ -45,13 +45,21 @@ def check_interface_status(dut, interfaces):
     for intf in interfaces:
         expected_oper = "up" if intf in mg_ports else "down"
         expected_admin = "up" if intf in mg_ports else "down"
-        assert intf in intf_status, "Missing status for interface %s" % intf
-        assert intf_status[intf]["oper"] == expected_oper, \
-            "Oper status of interface %s is %s, expected '%s'" % (intf, intf_status[intf]["oper"], expected_oper)
-        assert intf_status[intf]["admin"] == expected_oper, \
-            "Admin status of interface %s is %s, expected '%s'" % (intf, intf_status[intf]["admin"], expected_admin)
+        if not intf in intf_status:
+            logging.info("Missing status for interface %s" % intf)
+            return False
+        if intf_status[intf]["oper"] != expected_oper:
+            logging.info("Oper status of interface %s is %s, expected '%s'" % (intf, intf_status[intf]["oper"], expected_oper))
+            return False
+        if intf_status[intf]["admin"] != expected_admin:
+            logging.info("Admin status of interface %s is %s, expected '%s'" % (intf, intf_status[intf]["admin"], expected_admin))
+            return False
 
     logging.info("Check interface status using the interface_facts module")
     intf_facts = dut.interface_facts(up_ports=mg_ports)["ansible_facts"]
     down_ports = intf_facts["ansible_interface_link_down_ports"]
-    assert len(down_ports) == 0, "Some interfaces are down: %s" % str(down_ports)
+    if len(down_ports) != 0:
+        logging.info("Some interfaces are down: %s" % str(down_ports))
+        return False
+
+    return True

--- a/tests/platform/test_reboot.py
+++ b/tests/platform/test_reboot.py
@@ -18,9 +18,8 @@ import pytest
 from platform_fixtures import conn_graph_facts
 from common.utilities import wait_until
 from check_critical_services import check_critical_services
-from check_interface_status import check_interface_status
 from check_transceiver_status import check_transceiver_basic
-from check_transceiver_status import all_transceivers_detected
+from check_all_interface_info import check_interface_information
 
 
 def reboot_and_check(localhost, dut, interfaces, reboot_type="cold"):
@@ -58,11 +57,8 @@ def reboot_and_check(localhost, dut, interfaces, reboot_type="cold"):
     check_critical_services(dut)
 
     logging.info("Wait some time for all the transceivers to be detected")
-    assert wait_until(300, 20, all_transceivers_detected, dut, interfaces), \
-        "Not all transceivers are detected in 300 seconds"
-
-    logging.info("Check interface status")
-    check_interface_status(dut, interfaces)
+    assert wait_until(300, 20, check_interface_information, dut, interfaces), \
+        "Not all transceivers are detected or interfaces are up in 300 seconds"
 
     logging.info("Check transceiver status")
     check_transceiver_basic(dut, interfaces)

--- a/tests/platform/test_reload_config.py
+++ b/tests/platform/test_reload_config.py
@@ -13,9 +13,8 @@ import sys
 from platform_fixtures import conn_graph_facts
 from common.utilities import wait_until
 from check_critical_services import check_critical_services
-from check_interface_status import check_interface_status
 from check_transceiver_status import check_transceiver_basic
-from check_transceiver_status import all_transceivers_detected
+from check_all_interface_info import check_interface_information
 
 
 def test_reload_configuration(testbed_devices, conn_graph_facts):
@@ -33,12 +32,8 @@ def test_reload_configuration(testbed_devices, conn_graph_facts):
     check_critical_services(ans_host)
 
     logging.info("Wait some time for all the transceivers to be detected")
-    assert wait_until(300, 20, all_transceivers_detected, ans_host, interfaces), \
+    assert wait_until(300, 20, check_interface_information, ans_host, interfaces), \
         "Not all transceivers are detected in 300 seconds"
-
-    logging.info("Check interface status")
-    time.sleep(60)
-    check_interface_status(ans_host, interfaces)
 
     logging.info("Check transceiver status")
     check_transceiver_basic(ans_host, interfaces)

--- a/tests/platform/test_sequential_restart.py
+++ b/tests/platform/test_sequential_restart.py
@@ -15,10 +15,8 @@ import pytest
 from platform_fixtures import conn_graph_facts
 from common.utilities import wait_until
 from check_critical_services import check_critical_services
-from check_interface_status import check_interface_status
 from check_transceiver_status import check_transceiver_basic
-from check_transceiver_status import all_transceivers_detected
-
+from check_all_interface_info import check_interface_information
 
 def restart_service_and_check(localhost, dut, service, interfaces):
     """
@@ -32,12 +30,8 @@ def restart_service_and_check(localhost, dut, service, interfaces):
     check_critical_services(dut)
 
     logging.info("Wait some time for all the transceivers to be detected")
-    assert wait_until(300, 20, all_transceivers_detected, dut, interfaces), \
-        "Not all transceivers are detected in 300 seconds"
-
-    logging.info("Check interface status")
-    time.sleep(60)
-    check_interface_status(dut, interfaces)
+    assert wait_until(300, 20, check_interface_information, dut, interfaces), \
+        "Not all interface information are detected within 300 seconds"
 
     logging.info("Check transceiver status")
     check_transceiver_basic(dut, interfaces)


### PR DESCRIPTION

### Description of PR
Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Originally, the logic was to wait until all sfp modules detected or 300 seconds and then to wait 60 seconds and then to check interface status.
But sometimes sfp modules are detected very faster than interfaces being up, which fails the test.
We make check_interface_status tolerance the possibility that some interfaces are not up after all sfp modules detected via combine interface status checker and sfp module checker together.


#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
