### PR TITLE
[simple-fib] Fix vm CPU hog issue in ECMP test.

### DIFF
--- a/ansible/roles/test/tasks/simple-fib.yml
+++ b/ansible/roles/test/tasks/simple-fib.yml
@@ -6,7 +6,7 @@
 
 - debug : msg="Start FIB Test"
 
-- set_fact: mtu=9114
+- set_fact: mtu=1500
   when: mtu is not defined
 
 - name: "Start PTF runner"


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
The ecmp test works by sending 10000 packets to DUT for l3 forwarding and then checking whether the forwarded packets are load-balanced. However, the default mtu for this test is 9112. With such mtu the VM CPU utilization can rise to 100%, which prevent routing protocols and LACP from running and then causes routing entries on DUT withdrawn and LAG interfaces flapped and fails the test.
Fix the issue by using 1500 as the MTU to avoid hogging VM CPU.

#### How did you verify/test it?
Run test on all topo.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
