### PR TITLE
[test_reboot]wrap the reboot-cause check into a wait-until logic

### DIFF
--- a/tests/platform/test_reboot.py
+++ b/tests/platform/test_reboot.py
@@ -132,7 +132,6 @@ def reboot_and_check(localhost, dut, interfaces, reboot_type=REBOOT_TYPE_COLD, r
     check_critical_services(dut)
 
     logging.info("Check reboot cause")
-    check_reboot_cause(dut, reboot_cause)
     assert wait_until(120, 20, check_reboot_cause, dut, reboot_cause), \
         "got reboot-cause failed after rebooted by %s" % reboot_cause
 

--- a/tests/platform/test_reboot.py
+++ b/tests/platform/test_reboot.py
@@ -77,7 +77,7 @@ def check_reboot_cause(dut, reboot_cause_expected):
     reboot_cause_got = output["stdout"]
     logging.debug("show reboot-cause returns {}".format(reboot_cause_got))
     m = re.search(reboot_cause_expected, reboot_cause_got)
-    assert m is not None, "got reboot-cause %s after rebooted by %s" % (reboot_cause_got, reboot_cause_expected)
+    return m is not None
 
 
 def reboot_and_check(localhost, dut, interfaces, reboot_type=REBOOT_TYPE_COLD, reboot_helper=None, reboot_kwargs=None):
@@ -131,8 +131,14 @@ def reboot_and_check(localhost, dut, interfaces, reboot_type=REBOOT_TYPE_COLD, r
     logging.info("Wait until all critical services are fully started")
     check_critical_services(dut)
 
-    logging.info("Check reboot cause")
-    check_reboot_cause(dut, reboot_cause)
+    if dut.facts["hwsku"] in sku_supporting_reboot_cause_test:
+        logging.info("Check reboot cause")
+        check_reboot_cause(dut, reboot_cause)
+        assert wait_until(120, 20, check_reboot_cause, dut, reboot_cause), \
+            "got reboot-cause failed after rebooted by %s" % reboot_cause
+    else:
+        logging.info("Reboot-cause check skipped because %s doesn't support it" % dut.facts["hwsku"])
+
 
     if reboot_ctrl_dict[reboot_type]["test_reboot_cause_only"]:
         logging.info("Further checking skipped for %s test which intends to verify reboot-cause only".format(reboot_type))

--- a/tests/platform/test_reboot.py
+++ b/tests/platform/test_reboot.py
@@ -131,14 +131,10 @@ def reboot_and_check(localhost, dut, interfaces, reboot_type=REBOOT_TYPE_COLD, r
     logging.info("Wait until all critical services are fully started")
     check_critical_services(dut)
 
-    if dut.facts["hwsku"] in sku_supporting_reboot_cause_test:
-        logging.info("Check reboot cause")
-        check_reboot_cause(dut, reboot_cause)
-        assert wait_until(120, 20, check_reboot_cause, dut, reboot_cause), \
-            "got reboot-cause failed after rebooted by %s" % reboot_cause
-    else:
-        logging.info("Reboot-cause check skipped because %s doesn't support it" % dut.facts["hwsku"])
-
+    logging.info("Check reboot cause")
+    check_reboot_cause(dut, reboot_cause)
+    assert wait_until(120, 20, check_reboot_cause, dut, reboot_cause), \
+        "got reboot-cause failed after rebooted by %s" % reboot_cause
 
     if reboot_ctrl_dict[reboot_type]["test_reboot_cause_only"]:
         logging.info("Further checking skipped for %s test which intends to verify reboot-cause only".format(reboot_type))


### PR DESCRIPTION
### Description of PR

Summary:
In the reboot cause test it is assumed that the reboot-cause is available as soon as the critical services ready. However, PR [Delay process-reboot-cause service until network connection is stable #4003](https://github.com/azure/sonic-buildimage/pull/4003) introduces an extra amount of seconds and fails the assumption. 

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Wrap the reboot-cause-check into a wait-until logic so that it can wait for the process-reboot-cause for a few seconds.

#### How did you verify/test it?
Run reboot cause test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
