### PR TITLE
Only compute vlan parameters for t0 series topo when generate minigraph

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -89,7 +89,7 @@
       vlan_config: "{{ vlan_config | default(None) }}"
     delegate_to: localhost
     when:
-      - ("'host_interfaces' in vm_topo_config") and ("'tor' in vm_topo_config['dut_type'] | lower") and ("'t0' in testbed_facts['topo']")
+      - ("'host_interfaces' in vm_topo_config") and ("'tor' in vm_topo_config['dut_type'] | lower")
       - testbed_facts['topo'] in ["t0", "t0-16", "t0-52", "t0-56", "t0-64", "t0-64-32", "t0-116"]
 
   - name: find all interface indexes mapping connecting to VM

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -88,7 +88,9 @@
       port_alias: "{{ port_alias }}"
       vlan_config: "{{ vlan_config | default(None) }}"
     delegate_to: localhost
-    when: ("'host_interfaces' in vm_topo_config") and ("'tor' in vm_topo_config['dut_type'] | lower")
+    when:
+      - ("'host_interfaces' in vm_topo_config") and ("'tor' in vm_topo_config['dut_type'] | lower") and ("'t0' in testbed_facts['topo']")
+      - testbed_facts['topo'] in ["t0", "t0-16", "t0-52", "t0-56", "t0-64", "t0-64-32", "t0-116"]
 
   - name: find all interface indexes mapping connecting to VM
     set_fact:


### PR DESCRIPTION
### Description of PR
Summary:
Fixes # (issue)
Only compute vlan parameters for t0 series topo (t0, t0-xx).
PR [[ansible] Adding support for multi vlans #1353](https://github.com/azure/sonic-mgmt/pull/1353) introduces some vlan features but only supported on t0 series topo. 
However, it tries to call this module on other topos like t1, which causes the following issue:
```
fatal: [mtbc-sonic-03-2700 -> localhost]: FAILED! => {
"changed": false, 
"msg": "Traceback (most recent call last):\n
File \"/tmp/ansible_vlan_config_payload_h5ngrh/__main__.py\", line 46, in main\n 
vlan_config = m_args['vm_topo_config']['DUT']['vlan_configs']['default_vlan_config']\n
KeyError: 'vlan_configs'\n"
}
```
This PR add logic of checking the topology and calling the module on t0 series only.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
