### PR TITLE
[everflow]fix issue: missing mirror_stage in testcase_6

### DIFF
--- a/ansible/roles/test/files/acstests/everflow_neighbor_test.py
+++ b/ansible/roles/test/files/acstests/everflow_neighbor_test.py
@@ -41,6 +41,7 @@ class EverflowNeighborTest(BaseTest):
         self.asic_type = self.test_params['asic_type']
         self.router_mac = self.test_params['router_mac']
         self.src_port = int(self.test_params['src_port'])
+        self.mirror_stage = self.test_params['mirror_stage']
         self.dst_mirror_ports = [
             int(p)
             for p

--- a/ansible/roles/test/tasks/everflow_testbed/testcase_6.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_6.yml
@@ -41,6 +41,7 @@
         - src_port='{{src_port_ptf_id}}'
         - dst_ports='{{",".join((spine_ptf_ports))}}'
         - dst_mirror_ports='{{dst_port_1_ptf_id}}'
+        - mirror_stage='{{ mirror_stage }}'
       ptf_extra_options: "--relax --debug info"
 
   always:


### PR DESCRIPTION
### Description of PR

Summary:
Fixes the following issue
```
TASK [test : debug] ************************************************************ 
task path: /root/mars/workspace/sonic-mgmt/ansible/roles/test/tasks/ptf_runner.yml:52 
Wednesday 12 February 2020  17:08:08 +0000 (0:00:02.544)       0:14:55.685 **** 
ok: [arc-switch1004-t1-lag] => { 
    "out.stdout_lines": [ 
        "everflow_neighbor_test.EverflowNeighborTest ... ERROR", 
        "", 
"======================================================================", 
        "ERROR: everflow_neighbor_test.EverflowNeighborTest", 
        "----------------------------------------------------------------------", 
        "Traceback (most recent call last):", 
        "  File \"acstests/everflow_neighbor_test.py\", line 194, in runTest", 
        "    self.check_mirrored_packet()", 
        "  File \"acstests/everflow_neighbor_test.py\", line 137, in check_mirrored_packet", 
        "    if self.mirror_stage == \"egress\":", 
        "AttributeError: 'EverflowNeighborTest' object has no attribute 'mirror_stage'", 
        "", 
        "----------------------------------------------------------------------", 
        "Ran 1 test in 0.004s", 
        "", 
        "FAILED (errors=1)" 
    ] 
} 
Read vars_file 'vars/docker_registry.yml' 
```


### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
