### PR TITLE
Change the way of removing a port from a portchannel in ARP test (Fix #1505)

### DIFF
--- a/ansible/roles/test/tasks/arpall.yml
+++ b/ansible/roles/test/tasks/arpall.yml
@@ -30,7 +30,7 @@
       with_dict: "{{ minigraph_portchannels }}"
 
     - name: move interface {{ intf1 }} out of {{ po1 }}
-      shell: teamdctl {{ po1 }} port remove {{ intf1 }}
+      shell: config portchannel member del {{ po1 }} {{ intf1 }}
       become: yes
       when: po1 is defined
 
@@ -46,7 +46,7 @@
       with_dict: "{{ minigraph_portchannels }}"
 
     - name: move {{ intf2 }} out of {{ po2 }}
-      shell: teamdctl {{ po2 }} port remove {{ intf2 }}
+      shell: config portchannel member del {{ po2 }} {{ intf2 }}
       become: yes
       when: po2 is defined
 


### PR DESCRIPTION
### Description of PR

Summary:
Fix #1505
Use `config interface portchannel member del <portchannel> <member>` to remove a port from a port channel.
### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
