### PR TITLE
Fix qos issues

### DIFF
--- a/ansible/roles/test/tasks/qos_sai.yml
+++ b/ansible/roles/test/tasks/qos_sai.yml
@@ -117,6 +117,21 @@
         - src_port_ip='{{src_port_ip}}'
       when: testbed_type in ['t0', 't0-64', 't0-116'] or arp_entries.stdout.find('incomplete') == -1
 
+    - include_tasks: qos_sai_ptf.yml
+      vars:
+        test_name: populate arp on all ports
+        test_path: sai_qos_tests.ARPpopulatePTF
+        test_params:
+        - dst_port_id='{{dst_port_id}}'
+        - dst_port_ip='{{dst_port_ip}}'
+        - dst_port_2_id='{{dst_port_2_id}}'
+        - dst_port_2_ip='{{dst_port_2_ip}}'
+        - dst_port_3_id='{{dst_port_3_id}}'
+        - dst_port_3_ip='{{dst_port_3_ip}}'
+        - src_port_id='{{src_port_id}}'
+        - src_port_ip='{{src_port_ip}}'
+      when: testbed_type in ['ptf32', 'ptf64']
+
     # XOFF limit
     - include_tasks: qos_sai_ptf.yml
       vars:


### PR DESCRIPTION
### Description of PR

Summary:
Fix some issues found during QoS test.
1. Test parameters are unable to be fetched in `testing_port_ip_facts`. need to use `eval` statement.
2. Fix the issue that `dst_port_ip` and `dst_port_id` are not initialized in `PFCtest`.
3. Add debug info in `WRRtest` for the purpose of providing detail result in case of failure.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
