### PR TITLE
[QoS] Support designating the packet size when testing water mark of shared buffer

### DIFF
--- a/ansible/roles/test/tasks/qos_sai.yml
+++ b/ansible/roles/test/tasks/qos_sai.yml
@@ -295,8 +295,10 @@
         - pkts_num_fill_min='{{qp.wm_pg_shared_lossless.pkts_num_fill_min}}'
         - pkts_num_fill_shared='{{qp.wm_pg_shared_lossless.pkts_num_trig_pfc}}'
         - cell_size='{{qp.wm_pg_shared_lossless.cell_size}}'
+        - packet_size='{{qp.wm_pg_shared_lossless.packet_size}}'
       when: minigraph_hwsku is defined and
             (minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8'])
+
     - debug:
         var: out.stdout_lines
       when: minigraph_hwsku is defined and
@@ -324,8 +326,10 @@
         - pkts_num_fill_min='{{qp.wm_pg_shared_lossy.pkts_num_fill_min}}'
         - pkts_num_fill_shared='{{qp.wm_pg_shared_lossy.pkts_num_trig_egr_drp|int - 1}}'
         - cell_size='{{qp.wm_pg_shared_lossy.cell_size}}'
+        - packet_size='{{qp.wm_pg_shared_lossless.packet_size}}'
       when: minigraph_hwsku is defined and
             minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8']
+
     - debug:
         var: out.stdout_lines
       when: minigraph_hwsku is defined and

--- a/ansible/roles/test/tasks/qos_sai.yml
+++ b/ansible/roles/test/tasks/qos_sai.yml
@@ -295,10 +295,8 @@
         - pkts_num_fill_min='{{qp.wm_pg_shared_lossless.pkts_num_fill_min}}'
         - pkts_num_fill_shared='{{qp.wm_pg_shared_lossless.pkts_num_trig_pfc}}'
         - cell_size='{{qp.wm_pg_shared_lossless.cell_size}}'
-        - packet_size='{{qp.wm_pg_shared_lossless.packet_size}}'
       when: minigraph_hwsku is defined and
             (minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8'])
-
     - debug:
         var: out.stdout_lines
       when: minigraph_hwsku is defined and
@@ -326,10 +324,8 @@
         - pkts_num_fill_min='{{qp.wm_pg_shared_lossy.pkts_num_fill_min}}'
         - pkts_num_fill_shared='{{qp.wm_pg_shared_lossy.pkts_num_trig_egr_drp|int - 1}}'
         - cell_size='{{qp.wm_pg_shared_lossy.cell_size}}'
-        - packet_size='{{qp.wm_pg_shared_lossless.packet_size}}'
       when: minigraph_hwsku is defined and
             minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8']
-
     - debug:
         var: out.stdout_lines
       when: minigraph_hwsku is defined and


### PR DESCRIPTION
### Description of PR
Support designating the packet size when testing the watermark of the shared buffer.
The logic of the shared buffer watermark test is sending packets to occupy the shared buffer and then polling its watermark. Originally small packets were sent to occupy the shared buffer.
However, it's a very rare scenario that all shared buffer is occupied by small packets. To make it more generic and close to the real world scenario, we are going to support arbitrary packet size.

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
