### PR TITLE
[QoS] Support generating QoS test parameters according to configuration on Mellanox platform

### DIFF
--- a/tests/qos/files/mellanox/qos_param_generator.py
+++ b/tests/qos/files/mellanox/qos_param_generator.py
@@ -1,0 +1,146 @@
+import math
+
+class QosParamMellanox(object):
+    def __init__(self, qos_params, asictype, speed_cablelen, ingressLosslessProfile, ingressLossyProfile, egressLosslessProfile, egressLossyProfile):
+        asic_param_dic = {
+            'spc1': {
+                'cellsize': 96,
+                'headroom_overhead': 95,
+                'hysteresis': 0
+            },
+            'spc2': {
+                'cellsize': 144,
+                'headroom_overhead': 64,
+                'hysteresis': 0
+            },
+            'spc3': {
+                'cellsize': 144,
+                'headroom_overhead': 64,
+                'hysteresis': 0
+            }
+        }
+
+        self.asictype = asictype
+        self.cellsize = asic_param_dic[asictype]['cellsize']
+        self.headroom_overhead = asic_param_dic[asictype]['headroom_overhead']
+        self.hysteresis = asic_param_dic[asictype]['hysteresis']
+        self.speed_cablelen = speed_cablelen
+        self.lossless_profile = "pg_lossless_{}_profile".format(speed_cablelen)
+        self.pools_info = {}
+        self.qos_parameters = {}
+        self.qos_params_mlnx = qos_params
+        self.qos_params_mlnx[self.speed_cablelen] = self.qos_params_mlnx['profile']
+        self.ingressLosslessProfile = ingressLosslessProfile
+        self.ingressLossyProfile = ingressLossyProfile
+        self.egressLosslessProfile = egressLosslessProfile
+        self.egressLossyProfile = egressLossyProfile
+
+        return
+
+    def run(self):
+        """
+            Main method of the class
+            Returns the dictionary containing all the parameters required for the qos test
+        """
+        self.collect_qos_configurations()
+        self.calculate_parameters()
+        return self.qos_params_mlnx
+
+    def collect_qos_configurations(self):
+        """
+            Collect qos configuration from the following fixtures
+                ingressLosslessProfile
+                egressLossyProfile
+        """
+        xon = int(math.ceil(float(self.ingressLosslessProfile['xon']) / self.cellsize))
+        xoff = int(math.ceil(float(self.ingressLosslessProfile['xoff']) / self.cellsize))
+        headroom = xon + xoff
+        ingress_lossless_size = int(math.ceil(float(self.ingressLosslessProfile['static_th']) / self.cellsize)) - headroom
+        egress_lossy_size = int(math.ceil(float(self.egressLossyProfile['static_th']) / self.cellsize))
+
+        pkts_num_trig_pfc = ingress_lossless_size + xon
+        pkts_num_trig_ingr_drp = ingress_lossless_size + headroom - self.headroom_overhead
+        pkts_num_dismiss_pfc = ingress_lossless_size + 1
+        pkts_num_trig_egr_drp = egress_lossy_size + 1
+
+        self.qos_parameters['pkts_num_trig_pfc'] = pkts_num_trig_pfc
+        self.qos_parameters['pkts_num_trig_ingr_drp'] = pkts_num_trig_ingr_drp
+        self.qos_parameters['pkts_num_dismiss_pfc'] = pkts_num_dismiss_pfc
+        self.qos_parameters['pkts_num_trig_egr_drp'] = pkts_num_trig_egr_drp
+
+    def calculate_parameters(self):
+        """
+            Generate qos test parameters based on the configuration
+                xon
+                xoff
+                wm_pg_headroom
+                wm_pg_shared_lossless
+                wm_q_shared_lossless
+                lossy_queue_1
+                wm_pg_shared_lossy
+                wm_q_shared_lossy
+                wm_buf_pool_lossless
+                wm_buf_pool_lossy
+        """
+        pkts_num_trig_pfc = self.qos_parameters['pkts_num_trig_pfc']
+        pkts_num_trig_ingr_drp = self.qos_parameters['pkts_num_trig_ingr_drp']
+        pkts_num_dismiss_pfc = self.qos_parameters['pkts_num_dismiss_pfc']
+        pkts_num_trig_egr_drp = self.qos_parameters['pkts_num_trig_egr_drp']
+
+        xoff = {}
+        xoff['pkts_num_trig_pfc'] = pkts_num_trig_pfc
+        xoff['pkts_num_trig_ingr_drp'] = pkts_num_trig_ingr_drp
+        # One motivation of margin is to tolerance the deviation.
+        # We need a larger margin on SPC2/3
+        if self.asictype != 'spc1':
+            xoff['pkts_num_margin'] = 3
+        self.qos_params_mlnx[self.speed_cablelen]['xoff_1'].update(xoff)
+        self.qos_params_mlnx[self.speed_cablelen]['xoff_2'].update(xoff)
+
+        xon = {}
+        xon['pkts_num_trig_pfc'] = pkts_num_trig_pfc
+        xon['pkts_num_dismiss_pfc'] = pkts_num_dismiss_pfc
+        xon['pkts_num_hysteresis'] = self.hysteresis
+        if self.asictype != 'spc1':
+            xon['pkts_num_margin'] = 2
+        self.qos_params_mlnx['xon_1'].update(xon)
+        self.qos_params_mlnx['xon_2'].update(xon)
+
+        wm_pg_headroom = self.qos_params_mlnx[self.speed_cablelen]['wm_pg_headroom']
+        wm_pg_headroom['pkts_num_trig_pfc'] = pkts_num_trig_pfc
+        wm_pg_headroom['pkts_num_trig_ingr_drp'] = pkts_num_trig_ingr_drp
+        wm_pg_headroom['cell_size'] = self.cellsize
+        if self.asictype == 'spc1':
+            wm_pg_headroom['pkts_num_margin'] = 1
+        else:
+            wm_pg_headroom['pkts_num_margin'] = 2
+
+        wm_pg_shared_lossless = self.qos_params_mlnx['wm_pg_shared_lossless']
+        wm_pg_shared_lossless['pkts_num_trig_pfc'] = pkts_num_dismiss_pfc
+        wm_pg_shared_lossless['cell_size'] = self.cellsize
+
+        wm_q_shared_lossless = self.qos_params_mlnx[self.speed_cablelen]['wm_q_shared_lossless']
+        wm_q_shared_lossless['pkts_num_trig_ingr_drp'] = pkts_num_trig_ingr_drp
+        wm_q_shared_lossless['cell_size'] = self.cellsize
+
+        lossy_queue = self.qos_params_mlnx['lossy_queue_1']
+        lossy_queue['pkts_num_trig_egr_drp'] = pkts_num_trig_egr_drp - 1
+        lossy_queue['cell_size'] = self.cellsize
+
+        wm_shared_lossy = {}
+        wm_shared_lossy['pkts_num_trig_egr_drp'] = pkts_num_trig_egr_drp
+        wm_shared_lossy['cell_size'] = self.cellsize
+        self.qos_params_mlnx['wm_pg_shared_lossy'].update(wm_shared_lossy)
+        self.qos_params_mlnx['wm_q_shared_lossy'].update(wm_shared_lossy)
+
+        wm_buf_pool_lossless = self.qos_params_mlnx['wm_buf_pool_lossless']
+        wm_buf_pool_lossless['pkts_num_trig_pfc'] = pkts_num_trig_pfc
+        wm_buf_pool_lossless['pkts_num_trig_ingr_drp'] = pkts_num_trig_ingr_drp
+        wm_buf_pool_lossless['cell_size'] = self.cellsize
+
+        wm_buf_pool_lossy = self.qos_params_mlnx['wm_buf_pool_lossy']
+        wm_buf_pool_lossy['pkts_num_trig_egr_drp'] = pkts_num_trig_egr_drp
+        wm_buf_pool_lossy['cell_size'] = self.cellsize
+
+        for i in range(4):
+            self.qos_params_mlnx['ecn_{}'.format(i+1)]['cell_size'] = self.cellsize

--- a/tests/qos/files/mellanox/qos_param_generator.py
+++ b/tests/qos/files/mellanox/qos_param_generator.py
@@ -1,35 +1,35 @@
 import math
 
 class QosParamMellanox(object):
-    def __init__(self, qos_params, asictype, speed_cablelen, ingressLosslessProfile, ingressLossyProfile, egressLosslessProfile, egressLossyProfile):
+    def __init__(self, qos_params, asic_type, speed_cable_len, ingressLosslessProfile, ingressLossyProfile, egressLosslessProfile, egressLossyProfile):
         asic_param_dic = {
             'spc1': {
-                'cellsize': 96,
+                'cell_size': 96,
                 'headroom_overhead': 95,
                 'hysteresis': 0
             },
             'spc2': {
-                'cellsize': 144,
+                'cell_size': 144,
                 'headroom_overhead': 64,
                 'hysteresis': 0
             },
             'spc3': {
-                'cellsize': 144,
+                'cell_size': 144,
                 'headroom_overhead': 64,
                 'hysteresis': 0
             }
         }
 
-        self.asictype = asictype
-        self.cellsize = asic_param_dic[asictype]['cellsize']
-        self.headroom_overhead = asic_param_dic[asictype]['headroom_overhead']
-        self.hysteresis = asic_param_dic[asictype]['hysteresis']
-        self.speed_cablelen = speed_cablelen
-        self.lossless_profile = "pg_lossless_{}_profile".format(speed_cablelen)
+        self.asic_type = asic_type
+        self.cell_size = asic_param_dic[asic_type]['cell_size']
+        self.headroom_overhead = asic_param_dic[asic_type]['headroom_overhead']
+        self.hysteresis = asic_param_dic[asic_type]['hysteresis']
+        self.speed_cable_len = speed_cable_len
+        self.lossless_profile = "pg_lossless_{}_profile".format(speed_cable_len)
         self.pools_info = {}
         self.qos_parameters = {}
         self.qos_params_mlnx = qos_params
-        self.qos_params_mlnx[self.speed_cablelen] = self.qos_params_mlnx['profile']
+        self.qos_params_mlnx[self.speed_cable_len] = self.qos_params_mlnx['profile']
         self.ingressLosslessProfile = ingressLosslessProfile
         self.ingressLossyProfile = ingressLossyProfile
         self.egressLosslessProfile = egressLosslessProfile
@@ -52,11 +52,11 @@ class QosParamMellanox(object):
                 ingressLosslessProfile
                 egressLossyProfile
         """
-        xon = int(math.ceil(float(self.ingressLosslessProfile['xon']) / self.cellsize))
-        xoff = int(math.ceil(float(self.ingressLosslessProfile['xoff']) / self.cellsize))
+        xon = int(math.ceil(float(self.ingressLosslessProfile['xon']) / self.cell_size))
+        xoff = int(math.ceil(float(self.ingressLosslessProfile['xoff']) / self.cell_size))
         headroom = xon + xoff
-        ingress_lossless_size = int(math.ceil(float(self.ingressLosslessProfile['static_th']) / self.cellsize)) - headroom
-        egress_lossy_size = int(math.ceil(float(self.egressLossyProfile['static_th']) / self.cellsize))
+        ingress_lossless_size = int(math.ceil(float(self.ingressLosslessProfile['static_th']) / self.cell_size)) - headroom
+        egress_lossy_size = int(math.ceil(float(self.egressLossyProfile['static_th']) / self.cell_size))
 
         pkts_num_trig_pfc = ingress_lossless_size + xon
         pkts_num_trig_ingr_drp = ingress_lossless_size + headroom - self.headroom_overhead
@@ -92,55 +92,55 @@ class QosParamMellanox(object):
         xoff['pkts_num_trig_ingr_drp'] = pkts_num_trig_ingr_drp
         # One motivation of margin is to tolerance the deviation.
         # We need a larger margin on SPC2/3
-        if self.asictype != 'spc1':
+        if self.asic_type != 'spc1':
             xoff['pkts_num_margin'] = 3
-        self.qos_params_mlnx[self.speed_cablelen]['xoff_1'].update(xoff)
-        self.qos_params_mlnx[self.speed_cablelen]['xoff_2'].update(xoff)
+        self.qos_params_mlnx[self.speed_cable_len]['xoff_1'].update(xoff)
+        self.qos_params_mlnx[self.speed_cable_len]['xoff_2'].update(xoff)
 
         xon = {}
         xon['pkts_num_trig_pfc'] = pkts_num_trig_pfc
         xon['pkts_num_dismiss_pfc'] = pkts_num_dismiss_pfc
         xon['pkts_num_hysteresis'] = self.hysteresis
-        if self.asictype != 'spc1':
+        if self.asic_type != 'spc1':
             xon['pkts_num_margin'] = 2
         self.qos_params_mlnx['xon_1'].update(xon)
         self.qos_params_mlnx['xon_2'].update(xon)
 
-        wm_pg_headroom = self.qos_params_mlnx[self.speed_cablelen]['wm_pg_headroom']
+        wm_pg_headroom = self.qos_params_mlnx[self.speed_cable_len]['wm_pg_headroom']
         wm_pg_headroom['pkts_num_trig_pfc'] = pkts_num_trig_pfc
         wm_pg_headroom['pkts_num_trig_ingr_drp'] = pkts_num_trig_ingr_drp
-        wm_pg_headroom['cell_size'] = self.cellsize
-        if self.asictype == 'spc1':
+        wm_pg_headroom['cell_size'] = self.cell_size
+        if self.asic_type == 'spc1':
             wm_pg_headroom['pkts_num_margin'] = 1
         else:
             wm_pg_headroom['pkts_num_margin'] = 2
 
         wm_pg_shared_lossless = self.qos_params_mlnx['wm_pg_shared_lossless']
         wm_pg_shared_lossless['pkts_num_trig_pfc'] = pkts_num_dismiss_pfc
-        wm_pg_shared_lossless['cell_size'] = self.cellsize
+        wm_pg_shared_lossless['cell_size'] = self.cell_size
 
-        wm_q_shared_lossless = self.qos_params_mlnx[self.speed_cablelen]['wm_q_shared_lossless']
+        wm_q_shared_lossless = self.qos_params_mlnx[self.speed_cable_len]['wm_q_shared_lossless']
         wm_q_shared_lossless['pkts_num_trig_ingr_drp'] = pkts_num_trig_ingr_drp
-        wm_q_shared_lossless['cell_size'] = self.cellsize
+        wm_q_shared_lossless['cell_size'] = self.cell_size
 
         lossy_queue = self.qos_params_mlnx['lossy_queue_1']
         lossy_queue['pkts_num_trig_egr_drp'] = pkts_num_trig_egr_drp - 1
-        lossy_queue['cell_size'] = self.cellsize
+        lossy_queue['cell_size'] = self.cell_size
 
         wm_shared_lossy = {}
         wm_shared_lossy['pkts_num_trig_egr_drp'] = pkts_num_trig_egr_drp
-        wm_shared_lossy['cell_size'] = self.cellsize
+        wm_shared_lossy['cell_size'] = self.cell_size
         self.qos_params_mlnx['wm_pg_shared_lossy'].update(wm_shared_lossy)
         self.qos_params_mlnx['wm_q_shared_lossy'].update(wm_shared_lossy)
 
         wm_buf_pool_lossless = self.qos_params_mlnx['wm_buf_pool_lossless']
         wm_buf_pool_lossless['pkts_num_trig_pfc'] = pkts_num_trig_pfc
         wm_buf_pool_lossless['pkts_num_trig_ingr_drp'] = pkts_num_trig_ingr_drp
-        wm_buf_pool_lossless['cell_size'] = self.cellsize
+        wm_buf_pool_lossless['cell_size'] = self.cell_size
 
         wm_buf_pool_lossy = self.qos_params_mlnx['wm_buf_pool_lossy']
         wm_buf_pool_lossy['pkts_num_trig_egr_drp'] = pkts_num_trig_egr_drp
-        wm_buf_pool_lossy['cell_size'] = self.cellsize
+        wm_buf_pool_lossy['cell_size'] = self.cell_size
 
         for i in range(4):
-            self.qos_params_mlnx['ecn_{}'.format(i+1)]['cell_size'] = self.cellsize
+            self.qos_params_mlnx['ecn_{}'.format(i+1)]['cell_size'] = self.cell_size

--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -17,140 +17,130 @@
 #   xoff_1 for 50G
 #   xoff_2 for 100G
 qos_params:
-    spc1:
-        40000_5m:
+    mellanox:
+        profile:
             pkts_num_leak_out: 0
             xoff_1:
                 dscp: 3
                 ecn: 1
                 pg: 3
-                pkts_num_trig_pfc: 22038
-                pkts_num_trig_ingr_drp: 22115
             xoff_2:
                 dscp: 4
                 ecn: 1
                 pg: 4
-                pkts_num_trig_pfc: 22038
-                pkts_num_trig_ingr_drp: 22115
             wm_pg_headroom:
                 dscp: 3
                 ecn: 1
                 pg: 3
-                pkts_num_trig_pfc: 22038
-                pkts_num_trig_ingr_drp: 22115
-                cell_size: 96
-                packet_size: 300
+                pkts_num_leak_out: 0
             wm_q_shared_lossless:
                 dscp: 3
                 ecn: 1
                 queue: 3
+                pkts_num_leak_out: 0
                 pkts_num_fill_min: 0
-                pkts_num_trig_ingr_drp: 22115
-                cell_size: 96
-        40000_40m:
-            pkts_num_leak_out: 0
-            xoff_1:
-                dscp: 3
-                ecn: 1
-                pg: 3
-                pkts_num_trig_pfc: 22038
-                pkts_num_trig_ingr_drp: 22190
-            xoff_2:
-                dscp: 4
-                ecn: 1
-                pg: 4
-                pkts_num_trig_pfc: 22038
-                pkts_num_trig_ingr_drp: 22190
-            wm_pg_headroom:
-                dscp: 3
-                ecn: 1
-                pg: 3
-                pkts_num_trig_pfc: 22038
-                pkts_num_trig_ingr_drp: 22190
-                cell_size: 96
                 packet_size: 300
-            wm_q_shared_lossless:
-                dscp: 3
-                ecn: 1
-                queue: 3
-                pkts_num_fill_min: 0
-                pkts_num_trig_ingr_drp: 22190
-                cell_size: 96
         xon_1:
             dscp: 3
             ecn: 1
             pg: 3
-            pkts_num_trig_pfc: 22038
-            pkts_num_dismiss_pfc: 21847
+            pkts_num_leak_out: 0
         xon_2:
             dscp: 4
             ecn: 1
             pg: 4
-            pkts_num_trig_pfc: 22038
-            pkts_num_dismiss_pfc: 21847
+            pkts_num_leak_out: 0
         ecn_1:
             dscp: 8
             ecn: 0
             num_of_pkts: 5000
             limit: 182000
             min_limit: 180000
-            cell_size: 96
         ecn_2:
             dscp: 8
             ecn: 1
             num_of_pkts: 2047
             limit: 182320
             min_limit: 0
-            cell_size: 96
         ecn_3:
             dscp: 0
             ecn: 0
             num_of_pkts: 5000
             limit: 182000
             min_limit: 180000
-            cell_size: 96
         ecn_4:
             dscp: 0
             ecn: 1
             num_of_pkts: 2047
             limit: 182320
             min_limit: 0
-            cell_size: 96
         lossy_queue_1:
             dscp: 8
             ecn: 1
             pg: 0
-            pkts_num_trig_egr_drp: 67965
+            pkts_num_leak_out: 0
+            packet_size: 300
+            pkts_num_margin: 4
+        wrr:
+            ecn: 1
+            q0_num_of_pkts: 140
+            q1_num_of_pkts: 140
+            q2_num_of_pkts: 140
+            q3_num_of_pkts: 150
+            q4_num_of_pkts: 150
+            q5_num_of_pkts: 140
+            q6_num_of_pkts: 140
+            limit: 80
+            pkts_num_leak_out: 0
         wm_pg_shared_lossless:
             dscp: 3
             ecn: 1
             pg: 3
-            pkts_num_fill_min: 6
-            pkts_num_trig_pfc: 22038
-            cell_size: 96
+            pkts_num_leak_out: 0
+            pkts_num_fill_min: 0
             packet_size: 300
         wm_pg_shared_lossy:
-            dscp: 1
+            dscp: 8
             ecn: 1
             pg: 0
+            pkts_num_leak_out: 0
             pkts_num_fill_min: 0
-            pkts_num_trig_egr_drp: 67965
-            cell_size: 96
             packet_size: 300
         wm_q_shared_lossy:
-            dscp: 1
+            dscp: 8
             ecn: 1
-            queue: 1
+            queue: 0
+            pkts_num_leak_out: 0
             pkts_num_fill_min: 0
-            pkts_num_trig_egr_drp: 67965
-            cell_size: 96
-        wrr:
+            packet_size: 300
+        wm_buf_pool_lossless:
+            dscp: 3
             ecn: 1
-            q0_num_of_pkts: 600
-            q1_num_of_pkts: 400
-            q3_num_of_pkts: 500
-            q4_num_of_pkts: 500
+            pg: 3
+            queue: 3
+            pkts_num_leak_out: 0
+            pkts_num_fill_ingr_min: 0
+            pkts_num_fill_egr_min: 0
+        wm_buf_pool_lossy:
+            dscp: 8
+            ecn: 1
+            pg: 0
+            queue: 0
+            pkts_num_leak_out: 0
+            pkts_num_fill_ingr_min: 0
+            pkts_num_fill_egr_min: 0
+        wrr_chg:
+            ecn: 1
+            q0_num_of_pkts: 80
+            q1_num_of_pkts: 80
+            q2_num_of_pkts: 80
+            q3_num_of_pkts: 300
+            q4_num_of_pkts: 300
+            q5_num_of_pkts: 80
+            q6_num_of_pkts: 80
             limit: 80
+            pkts_num_leak_out: 48
+            lossy_weight: 8
     td2:
         40000_5m:
             pkts_num_leak_out: 48

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -44,6 +44,10 @@ class TestQosSai(QosSaiBase):
         'Arista-7260CX3-Q64'
     ]
 
+    def testParameter(self, duthost, dutQosConfig, ingressLosslessProfile, ingressLossyProfile, egressLosslessProfile):
+        logger.info("asictype {}".format(duthost.facts["asic_type"]))
+        logger.info("qosConfig {}".format(dutQosConfig))
+
     @pytest.mark.parametrize("xoffProfile", ["xoff_1", "xoff_2"])
     def testQosSaiPfcXoffLimit(self, xoffProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
                                ingressLosslessProfile, egressLosslessProfile):
@@ -82,6 +86,8 @@ class TestQosSai(QosSaiBase):
             "pkts_num_trig_pfc": qosConfig[xoffProfile]["pkts_num_trig_pfc"],
             "pkts_num_trig_ingr_drp": qosConfig[xoffProfile]["pkts_num_trig_ingr_drp"],
         }
+        if "pkts_num_margin" in qosConfig[xoffProfile].keys():
+            testParams["pkts_num_margin"] = qosConfig[xoffProfile]["pkts_num_margin"]
         testParams.update(dutTestParams["basicParams"])
         self.runPtfTest(ptfhost, testCase="sai_qos_tests.PFCtest", testParams=testParams)
 
@@ -123,8 +129,12 @@ class TestQosSai(QosSaiBase):
             "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
             "pkts_num_leak_out": qosConfig[portSpeedCableLength]["pkts_num_leak_out"],
             "pkts_num_trig_pfc": qosConfig[xonProfile]["pkts_num_trig_pfc"],
-            "pkts_num_dismiss_pfc": qosConfig[xonProfile]["pkts_num_dismiss_pfc"],
+            "pkts_num_dismiss_pfc": qosConfig[xonProfile]["pkts_num_dismiss_pfc"]
         }
+        if "pkts_num_hysteresis" in qosConfig[xonProfile].keys():
+            testParams["pkts_num_hysteresis"] = qosConfig[xonProfile]["pkts_num_hysteresis"]
+        if "pkts_num_margin" in qosConfig[xonProfile].keys():
+            testParams["pkts_num_margin"] = qosConfig[xonProfile]["pkts_num_margin"]
         testParams.update(dutTestParams["basicParams"])
         self.runPtfTest(ptfhost, testCase="sai_qos_tests.PFCXonTest", testParams=testParams)
 
@@ -207,6 +217,11 @@ class TestQosSai(QosSaiBase):
             "pkts_num_leak_out": qosConfig[portSpeedCableLength]["pkts_num_leak_out"],
             "pkts_num_trig_egr_drp": qosConfig["lossy_queue_1"]["pkts_num_trig_egr_drp"],
         }
+        if "packet_size" in qosConfig["lossy_queue_1"].keys():
+            testParams["packet_size"] = qosConfig["lossy_queue_1"]["packet_size"]
+            testParams["cell_size"] = qosConfig["lossy_queue_1"]["cell_size"]
+        if "pkts_num_margin" in qosConfig["lossy_queue_1"].keys():
+            testParams["pkts_num_margin"] = qosConfig["lossy_queue_1"]["pkts_num_margin"]
         testParams.update(dutTestParams["basicParams"])
         self.runPtfTest(ptfhost, testCase="sai_qos_tests.LossyQueueTest", testParams=testParams)
 
@@ -357,6 +372,8 @@ class TestQosSai(QosSaiBase):
             "pkts_num_trig_ingr_drp": qosConfig["wm_pg_headroom"]["pkts_num_trig_ingr_drp"],
             "cell_size": qosConfig["wm_pg_headroom"]["cell_size"],
         }
+        if "pkts_num_margin" in qosConfig["wm_pg_headroom"].keys():
+            testParams["pkts_num_margin"] = qosConfig["wm_pg_headroom"]["pkts_num_margin"]
         testParams.update(dutTestParams["basicParams"])
         self.runPtfTest(ptfhost, testCase="sai_qos_tests.PGHeadroomWatermarkTest", testParams=testParams)
 
@@ -397,6 +414,7 @@ class TestQosSai(QosSaiBase):
             "pkts_num_leak_out": dutQosConfig["param"][portSpeedCableLength]["pkts_num_leak_out"],
             "pkts_num_fill_min": qosConfig[queueProfile]["pkts_num_fill_min"],
             "pkts_num_trig_drp": triggerDrop,
+            "packet_size": qosConfig[queueProfile]["packet_size"],
             "cell_size": qosConfig[queueProfile]["cell_size"],
         }
         testParams.update(dutTestParams["basicParams"])

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -583,7 +583,10 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
         # Add slight tolerance in threshold characterization to consider
         # the case that cpu puts packets in the egress queue after we pause the egress
         # or the leak out is simply less than expected as we have occasionally observed
-        margin = 2
+        if 'pkts_num_margin' in self.test_params.keys():
+            margin = int(self.test_params['pkts_num_margin'])
+        else:
+            margin = 2
 
         sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
 
@@ -692,6 +695,10 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
         pkts_num_leak_out = int(self.test_params['pkts_num_leak_out'])
         pkts_num_trig_pfc = int(self.test_params['pkts_num_trig_pfc'])
         pkts_num_dismiss_pfc = int(self.test_params['pkts_num_dismiss_pfc'])
+        if 'pkts_num_hysteresis' in self.test_params.keys():
+            hysteresis = int(self.test_params['pkts_num_hysteresis'])
+        else:
+            hysteresis = 0
         default_packet_length = 64
         # get a snapshot of counter values at recv and transmit ports
         # queue_counters value is not of our interest here
@@ -702,7 +709,10 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
         # The number of packets that will trek into the headroom space;
         # We observe in test that if the packets are sent to multiple destination ports,
         # the ingress may not trigger PFC sharp at its boundary
-        margin = 1
+        if 'pkts_num_margin' in self.test_params.keys():
+            margin = int(self.test_params['pkts_num_margin'])
+        else:
+            margin = 1
 
         sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id, dst_port_2_id, dst_port_3_id])
 
@@ -1343,7 +1353,18 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
 
         pkts_num_leak_out = int(self.test_params['pkts_num_leak_out'])
         pkts_num_trig_egr_drp = int(self.test_params['pkts_num_trig_egr_drp'])
-        default_packet_length = 64
+        if 'packet_size' in self.test_params.keys():
+            default_packet_length = int(self.test_params['packet_size'])
+            cell_size = int(self.test_params['cell_size'])
+            if default_packet_length != 64:
+                cell_occupancy = (default_packet_length + cell_size - 1) / cell_size
+                pkts_num_trig_egr_drp /= cell_occupancy
+                # It is possible that pkts_num_trig_egr_drp * cell_occupancy < original pkts_num_trig_egr_drp,
+                # which probaly can fail the assert(xmit_counters[EGRESS_DROP] > xmit_counters_base[EGRESS_DROP])
+                # due to not sending enough packets.
+                # To avoid that we need a larger margin
+        else:
+            default_packet_length = 64
         pkt = simple_tcp_packet(pktlen=default_packet_length,
                                 eth_dst=router_mac if router_mac != '' else dst_port_mac,
                                 eth_src=src_port_mac,
@@ -1358,7 +1379,10 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
         # add slight tolerance in threshold characterization to consider
         # the case that cpu puts packets in the egress queue after we pause the egress
         # or the leak out is simply less than expected as we have occasionally observed
-        margin = 2
+        if 'pkts_num_margin' in self.test_params.keys():
+            margin = int(self.test_params['pkts_num_margin'])
+        else:
+            margin = 2
 
         sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
 
@@ -1495,7 +1519,6 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             time.sleep(8)
             q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(self.client, port_list[src_port_id])
             print >> sys.stderr, "exceeded pkts num sent: %d, expected watermark: %d, actual value: %d" % (pkts_num, ((expected_wm + cell_occupancy) * cell_size), pg_shared_wm_res[pg])
-#            assert(expected_wm == total_shared)
             assert(fragment < cell_occupancy)
             assert(expected_wm * cell_size <= pg_shared_wm_res[pg])
             assert(pg_shared_wm_res[pg] <= (expected_wm + margin + cell_occupancy) * cell_size)
@@ -1543,7 +1566,10 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         # Add slight tolerance in threshold characterization to consider
         # the case that cpu puts packets in the egress queue after we pause the egress
         # or the leak out is simply less than expected as we have occasionally observed
-        margin = 0
+        if 'pkts_num_margin' in self.test_params.keys():
+            margin = int(self.test_params['pkts_num_margin'])
+        else:
+            margin = 0
 
         sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
 
@@ -1571,8 +1597,8 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 send_packet(self, src_port_id, pkt, pkts_num)
                 time.sleep(8)
                 q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(self.client, port_list[src_port_id])
-                print >> sys.stderr, "lower bound: %d, actual value: %d, upper bound: %d" % ((expected_wm - margin) * cell_size, pg_headroom_wm_res[pg], (expected_wm * cell_size))
-                assert(pg_headroom_wm_res[pg] <= expected_wm * cell_size)
+                print >> sys.stderr, "lower bound: %d, actual value: %d, upper bound: %d" % ((expected_wm - margin) * cell_size, pg_headroom_wm_res[pg], ((expected_wm + margin) * cell_size))
+                assert(pg_headroom_wm_res[pg] <= (expected_wm + margin) * cell_size)
                 assert((expected_wm - margin) * cell_size <= pg_headroom_wm_res[pg])
 
                 pkts_num = pkts_inc
@@ -1581,9 +1607,11 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             send_packet(self, src_port_id, pkt, pkts_num)
             time.sleep(8)
             q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(self.client, port_list[src_port_id])
-            print >> sys.stderr, "exceeded pkts num sent: %d, actual value: %d, expected watermark: %d" % (pkts_num, pg_headroom_wm_res[pg], (expected_wm * cell_size))
+            print >> sys.stderr, "exceeded pkts num sent: %d" % (pkts_num)
+            print >> sys.stderr, "lower bound: %d, actual value: %d, upper bound: %d" % ((expected_wm - margin) * cell_size, pg_headroom_wm_res[pg], ((expected_wm + margin) * cell_size))
             assert(expected_wm == total_hdrm)
-            assert(pg_headroom_wm_res[pg] == expected_wm * cell_size)
+            assert(pg_headroom_wm_res[pg] <= (expected_wm + margin) * cell_size)
+            assert(expected_wm * cell_size <= pg_headroom_wm_res[pg])
 
         finally:
             sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
@@ -1611,12 +1639,17 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         pkts_num_fill_min = int(self.test_params['pkts_num_fill_min'])
         pkts_num_trig_drp = int(self.test_params['pkts_num_trig_drp'])
         cell_size = int(self.test_params['cell_size'])
+        if 'packet_size' in self.test_params.keys():
+            default_packet_length = int(self.test_params['packet_size'])
+        else:
+            default_packet_length = 64
+
+        cell_occupancy = (default_packet_length + cell_size - 1) / cell_size
 
         # Prepare TCP packet data
         tos = dscp << 2
         tos |= ecn
         ttl = 64
-        default_packet_length = 64
         pkt = simple_tcp_packet(pktlen=default_packet_length,
                                 eth_dst=router_mac if router_mac != '' else dst_port_mac,
                                 eth_src=src_port_mac,
@@ -1654,21 +1687,24 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             # first round sends only 1 packet
             expected_wm = 0
             total_shared = pkts_num_trig_drp - pkts_num_fill_min - 1
-            pkts_inc = total_shared >> 2
+            pkts_inc = (total_shared / cell_occupancy) >> 2
             pkts_num = 1 + margin
-            while (expected_wm < total_shared):
-                expected_wm += pkts_num
+            fragment = 0
+            while (expected_wm < total_shared - fragment):
+                expected_wm += pkts_num * cell_occupancy
                 if (expected_wm > total_shared):
-                    pkts_num -= (expected_wm - total_shared)
-                    expected_wm = total_shared
+                    diff = (expected_wm - total_shared + cell_occupancy - 1) / cell_occupancy
+                    pkts_num -= diff
+                    expected_wm -= diff * cell_occupancy
+                    fragment = total_shared - expected_wm
                 print >> sys.stderr, "pkts num to send: %d, total pkts: %d, queue shared: %d" % (pkts_num, expected_wm, total_shared)
 
                 send_packet(self, src_port_id, pkt, pkts_num)
                 time.sleep(8)
                 q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(self.client, port_list[dst_port_id])
-                print >> sys.stderr, "lower bound: %d, actual value: %d, upper bound: %d" % (expected_wm * cell_size, q_wm_res[queue], (expected_wm * cell_size))
-                assert(q_wm_res[queue] <= expected_wm * cell_size)
-                assert(expected_wm * cell_size <= q_wm_res[queue])
+                print >> sys.stderr, "lower bound: %d, actual value: %d, upper bound: %d" % ((expected_wm - margin) * cell_size, q_wm_res[queue], (expected_wm + margin) * cell_size)
+                assert(q_wm_res[queue] <= (expected_wm + margin) * cell_size)
+                assert((expected_wm - margin) * cell_size <= q_wm_res[queue])
 
                 pkts_num = pkts_inc
 
@@ -1676,10 +1712,10 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             send_packet(self, src_port_id, pkt, pkts_num)
             time.sleep(8)
             q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(self.client, port_list[dst_port_id])
-            print >> sys.stderr, "exceeded pkts num sent: %d, expected watermark: %d, actual value: %d" % (pkts_num, (expected_wm * cell_size), q_wm_res[queue])
-            assert(expected_wm == total_shared)
+            print >> sys.stderr, "exceeded pkts num sent: %d, actual value: %d, expected watermark: %d" % (pkts_num, q_wm_res[queue], ((expected_wm + cell_occupancy) * cell_size))
+            assert(fragment < cell_occupancy)
             assert(expected_wm * cell_size <= q_wm_res[queue])
-            assert(q_wm_res[queue] <= (expected_wm + margin) * cell_size)
+            assert(q_wm_res[queue] <= (expected_wm + margin + cell_occupancy * 2) * cell_size)
 
         finally:
             sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -1354,18 +1354,18 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
         pkts_num_leak_out = int(self.test_params['pkts_num_leak_out'])
         pkts_num_trig_egr_drp = int(self.test_params['pkts_num_trig_egr_drp'])
         if 'packet_size' in self.test_params.keys():
-            default_packet_length = int(self.test_params['packet_size'])
+            packet_length = int(self.test_params['packet_size'])
             cell_size = int(self.test_params['cell_size'])
-            if default_packet_length != 64:
-                cell_occupancy = (default_packet_length + cell_size - 1) / cell_size
+            if packet_length != 64:
+                cell_occupancy = (packet_length + cell_size - 1) / cell_size
                 pkts_num_trig_egr_drp /= cell_occupancy
                 # It is possible that pkts_num_trig_egr_drp * cell_occupancy < original pkts_num_trig_egr_drp,
                 # which probaly can fail the assert(xmit_counters[EGRESS_DROP] > xmit_counters_base[EGRESS_DROP])
                 # due to not sending enough packets.
                 # To avoid that we need a larger margin
         else:
-            default_packet_length = 64
-        pkt = simple_tcp_packet(pktlen=default_packet_length,
+            packet_length = 64
+        pkt = simple_tcp_packet(pktlen=packet_length,
                                 eth_dst=router_mac if router_mac != '' else dst_port_mac,
                                 eth_src=src_port_mac,
                                 ip_src=src_port_ip,
@@ -1445,17 +1445,17 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         pkts_num_fill_shared = int(self.test_params['pkts_num_fill_shared'])
         cell_size = int(self.test_params['cell_size'])
         if 'packet_size' in self.test_params.keys():
-            default_packet_length = int(self.test_params['packet_size'])
+            packet_length = int(self.test_params['packet_size'])
         else:
-            default_packet_length = 64
+            packet_length = 64
 
-        cell_occupancy = (default_packet_length + cell_size - 1) / cell_size
+        cell_occupancy = (packet_length + cell_size - 1) / cell_size
 
         # Prepare TCP packet data
         tos = dscp << 2
         tos |= ecn
         ttl = 64
-        pkt = simple_tcp_packet(pktlen=default_packet_length,
+        pkt = simple_tcp_packet(pktlen=packet_length,
                                 eth_dst=router_mac if router_mac != '' else dst_port_mac,
                                 eth_src=src_port_mac,
                                 ip_src=src_port_ip,
@@ -1640,17 +1640,17 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         pkts_num_trig_drp = int(self.test_params['pkts_num_trig_drp'])
         cell_size = int(self.test_params['cell_size'])
         if 'packet_size' in self.test_params.keys():
-            default_packet_length = int(self.test_params['packet_size'])
+            packet_length = int(self.test_params['packet_size'])
         else:
-            default_packet_length = 64
+            packet_length = 64
 
-        cell_occupancy = (default_packet_length + cell_size - 1) / cell_size
+        cell_occupancy = (packet_length + cell_size - 1) / cell_size
 
         # Prepare TCP packet data
         tos = dscp << 2
         tos |= ecn
         ttl = 64
-        pkt = simple_tcp_packet(pktlen=default_packet_length,
+        pkt = simple_tcp_packet(pktlen=packet_length,
                                 eth_dst=router_mac if router_mac != '' else dst_port_mac,
                                 eth_src=src_port_mac,
                                 ip_src=src_port_ip,

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -695,10 +695,6 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
         pkts_num_leak_out = int(self.test_params['pkts_num_leak_out'])
         pkts_num_trig_pfc = int(self.test_params['pkts_num_trig_pfc'])
         pkts_num_dismiss_pfc = int(self.test_params['pkts_num_dismiss_pfc'])
-        if 'pkts_num_hysteresis' in self.test_params.keys():
-            hysteresis = int(self.test_params['pkts_num_hysteresis'])
-        else:
-            hysteresis = 0
         default_packet_length = 64
         # get a snapshot of counter values at recv and transmit ports
         # queue_counters value is not of our interest here


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
1. Add a plugin that generates QoS test parameters according to configuration for the Mellanox platform.
   The plugin will be load fixture dutQosConfig
2. Sometimes a deviation can be introduced by calculating test parameters automatically.
   Support passing margin from the qos_params for the purpose of covering the deviation.
3. Support passing packet size from the qos_params for lossy queue and queue shared watermark test.

Signed-off-by: Stephen Sun <stephens@mellanox.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
