### PR TITLE
[copp] Fix ip2me entry name

### DIFF
--- a/ansible/roles/test/tasks/copp/ip2me_600.json
+++ b/ansible/roles/test/tasks/copp/ip2me_600.json
@@ -1,6 +1,6 @@
 [
     {
-         "COPP_TABLE:trap.group.nat.ip2me": {
+         "COPP_TABLE:trap.group.ip2me": {
              "cir":"600",
              "cbs":"600"
          },

--- a/ansible/roles/test/tasks/copp/ip2me_6000.json
+++ b/ansible/roles/test/tasks/copp/ip2me_6000.json
@@ -1,6 +1,6 @@
 [
     {
-         "COPP_TABLE:trap.group.nat.ip2me": {
+         "COPP_TABLE:trap.group.ip2me": {
              "cir":"6000",
              "cbs":"6000"
          },


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
copp entry for ip2me has been updated from COPP_TABLE:trap.group.nat.ip2me to COPP_TABLE:trap.group.ip2me.
Test case needs to be updated accordingly.

Signed-off-by: Stephen Sun <stephens@mellanox.com>
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
