### PR TITLE
Fix qos test issues in watermark and pfc

### DIFF
--- a/tests/qos/files/mellanox/qos_param_generator.py
+++ b/tests/qos/files/mellanox/qos_param_generator.py
@@ -114,8 +114,8 @@ class QosParamMellanox(object):
         wm_pg_headroom['pkts_num_trig_pfc'] = pkts_num_trig_pfc
         wm_pg_headroom['pkts_num_trig_ingr_drp'] = pkts_num_trig_ingr_drp
         wm_pg_headroom['cell_size'] = self.cell_size
-        if self.asic_type == 'spc1':
-            wm_pg_headroom['pkts_num_margin'] = 1
+        if self.asic_type == 'spc3':
+            wm_pg_headroom['pkts_num_margin'] = 3
         else:
             wm_pg_headroom['pkts_num_margin'] = 2
 

--- a/tests/qos/files/mellanox/qos_param_generator.py
+++ b/tests/qos/files/mellanox/qos_param_generator.py
@@ -102,11 +102,11 @@ class QosParamMellanox(object):
         xon = {}
         xon['pkts_num_trig_pfc'] = pkts_num_trig_pfc
         xon['pkts_num_dismiss_pfc'] = pkts_num_dismiss_pfc
-        xon['pkts_num_hysteresis'] = pkts_num_hysteresis
+        xon['pkts_num_hysteresis'] = pkts_num_hysteresis + 16
         if self.asic_type == 'spc2':
             xon['pkts_num_margin'] = 2
         elif self.asic_type == 'spc3':
-            xon['pkts_num_margin'] = 0
+            xon['pkts_num_margin'] = 3
         self.qos_params_mlnx['xon_1'].update(xon)
         self.qos_params_mlnx['xon_2'].update(xon)
 

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -1578,10 +1578,12 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         # send packets
         try:
             # send packets to trigger pfc but not trek into headroom
-            send_packet(self, src_port_id, pkt, pkts_num_leak_out + pkts_num_trig_pfc)
+            send_packet(self, src_port_id, pkt, pkts_num_leak_out + pkts_num_trig_pfc - margin)
             time.sleep(8)
             q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(self.client, port_list[src_port_id])
             assert(pg_headroom_wm_res[pg] == 0)
+
+            send_packet(self, src_port_id, pkt, margin)
 
             # send packet batch of fixed packet numbers to fill pg headroom
             # first round sends only 1 packet


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fix two QoS test issues on Mellanox platform.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fix two QoS test issues on Mellanox platform.

#### How did you do it?
In the headroom watermark test, it is expected that the watermark is multiple of cell size.
However, there is some deviation caused by the below reasons:
- The headroom size in SONiC is in bytes and isn't the multiple of cell size.
- The SAI calculate the headroom watermark as "sdk max occupancy" - "sonic configuration",
  if the value configured in SONiC doesn't aligned with cell size boundary, the watermark
  isn't cell size aligned.
Especially, when the packets start to trek to headroom (xoff zone), the headroom size isn't 0
(but it should be), which fails the headroom watermark test.
To tolerance the deviation, the number of packets to occupy all the shared buffer
is a bit less than it should be.

In the PFCXon test on 400G port, need to increase the margin size.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
