### PR TITLE
Expose an CLI option of post script in advanced reboot test to user

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -70,6 +70,7 @@ class AdvancedReboot:
         self.cleanupOldSonicImages = self.request.config.getoption("--cleanup_old_sonic_images")
         self.readyTimeout = self.request.config.getoption("--ready_timeout")
         self.replaceFastRebootScript = self.request.config.getoption("--replace_fast_reboot_script")
+        self.postRebootCheckScript = self.request.config.getoption("--post_reboot_check_script")
 
     def getHostMaxLen(self):
         '''
@@ -500,6 +501,10 @@ class AdvancedReboot:
         assert len(result['stderr_lines']) == 0, '/etc/sonic/config_db.json is missing'
 
         self.__runScript(['remove_ip.sh'], self.ptfhost)
+
+        if self.postRebootCheckScript:
+            logger.info('Run the post reboot check script')
+            self.__runScript([self.postRebootCheckScript], self.duthost)
 
         if not self.stayInTargetImage:
             self.__restorePrevImage()

--- a/tests/platform_tests/args/advanced_reboot_args.py
+++ b/tests/platform_tests/args/advanced_reboot_args.py
@@ -84,3 +84,11 @@ def add_advanced_reboot_args(parser):
         default=False,
         help="Replace fast-reboot script on DUT",
     )
+
+    parser.addoption(
+        "--post_reboot_check_script",
+        action="store",
+        type=str,
+        default=None,
+        help="Script for checking additional states on DUT"
+    )


### PR DESCRIPTION
Signed-off-by: Stephen Sun <stephens@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Expose an CLI option of post script in advanced reboot test to user

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Expose a CLI option by which the user can designate the script to run after the warm reboot to check something.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
