### PR TITLE
[Mellanox] Enlarge the margin for the PFCXontest on 4700 400G port

### DIFF
--- a/tests/qos/files/mellanox/qos_param_generator.py
+++ b/tests/qos/files/mellanox/qos_param_generator.py
@@ -105,12 +105,12 @@ class QosParamMellanox(object):
 
         xon = {}
         xon['pkts_num_trig_pfc'] = pkts_num_trig_pfc
-        xon['pkts_num_dismiss_pfc'] = pkts_num_dismiss_pfc
+        xon['pkts_num_dismiss_pfc'] = pkts_num_dismiss_pfc + self.extra_margin
         xon['pkts_num_hysteresis'] = pkts_num_hysteresis + 16
         if self.asic_type == 'spc2':
             xon['pkts_num_margin'] = 2
         elif self.asic_type == 'spc3':
-            xon['pkts_num_margin'] = 3 + self.extra_margin
+            xon['pkts_num_margin'] = 3
         self.qos_params_mlnx['xon_1'].update(xon)
         self.qos_params_mlnx['xon_2'].update(xon)
 

--- a/tests/qos/files/mellanox/qos_param_generator.py
+++ b/tests/qos/files/mellanox/qos_param_generator.py
@@ -22,6 +22,10 @@ class QosParamMellanox(object):
         self.headroom_overhead = asic_param_dic[asic_type]['headroom_overhead']
         if speed_cable_len[0:6] == '400000':
             self.headroom_overhead += 59
+            # for 400G ports we need an extra margin in case it is filled unbalancely between two buffer units
+            self.extra_margin = 16
+        else:
+            self.extra_margin = 0
         self.speed_cable_len = speed_cable_len
         self.lossless_profile = "pg_lossless_{}_profile".format(speed_cable_len)
         self.pools_info = {}
@@ -106,7 +110,7 @@ class QosParamMellanox(object):
         if self.asic_type == 'spc2':
             xon['pkts_num_margin'] = 2
         elif self.asic_type == 'spc3':
-            xon['pkts_num_margin'] = 3
+            xon['pkts_num_margin'] = 3 + self.extra_margin
         self.qos_params_mlnx['xon_1'].update(xon)
         self.qos_params_mlnx['xon_2'].update(xon)
 

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -736,7 +736,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                                     ip_dst=dst_port_ip,
                                     ip_tos=tos,
                                     ip_ttl=ttl)
-            send_packet(self, src_port_id, pkt, pkts_num_leak_out + pkts_num_trig_pfc - pkts_num_dismiss_pfc - hysteresis)
+            send_packet(self, src_port_id, pkt, pkts_num_leak_out + pkts_num_trig_pfc - pkts_num_dismiss_pfc - hysteresis - margin)
             # send packets to dst port 2, occupying the shared buffer
             pkt = simple_tcp_packet(pktlen=default_packet_length,
                                     eth_dst=router_mac if router_mac != '' else dst_port_2_mac,
@@ -745,7 +745,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                                     ip_dst=dst_port_2_ip,
                                     ip_tos=tos,
                                     ip_ttl=ttl)
-            send_packet(self, src_port_id, pkt, pkts_num_leak_out + margin + pkts_num_dismiss_pfc - 1 + hysteresis)
+            send_packet(self, src_port_id, pkt, pkts_num_leak_out + margin + pkts_num_dismiss_pfc - 1 + hysteresis + margin)
             # send 1 packet to dst port 3, triggering PFC
             pkt = simple_tcp_packet(pktlen=default_packet_length,
                                     eth_dst=router_mac if router_mac != '' else dst_port_3_mac,

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -736,7 +736,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                                     ip_dst=dst_port_ip,
                                     ip_tos=tos,
                                     ip_ttl=ttl)
-            send_packet(self, src_port_id, pkt, pkts_num_leak_out + pkts_num_trig_pfc - pkts_num_dismiss_pfc - hysteresis - margin)
+            send_packet(self, src_port_id, pkt, pkts_num_leak_out + pkts_num_trig_pfc - pkts_num_dismiss_pfc - hysteresis)
             # send packets to dst port 2, occupying the shared buffer
             pkt = simple_tcp_packet(pktlen=default_packet_length,
                                     eth_dst=router_mac if router_mac != '' else dst_port_2_mac,
@@ -745,7 +745,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                                     ip_dst=dst_port_2_ip,
                                     ip_tos=tos,
                                     ip_ttl=ttl)
-            send_packet(self, src_port_id, pkt, pkts_num_leak_out + 2 * margin + pkts_num_dismiss_pfc - 1 + hysteresis)
+            send_packet(self, src_port_id, pkt, pkts_num_leak_out + margin + pkts_num_dismiss_pfc - 1 + hysteresis)
             # send 1 packet to dst port 3, triggering PFC
             pkt = simple_tcp_packet(pktlen=default_packet_length,
                                     eth_dst=router_mac if router_mac != '' else dst_port_3_mac,

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -745,7 +745,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                                     ip_dst=dst_port_2_ip,
                                     ip_tos=tos,
                                     ip_ttl=ttl)
-            send_packet(self, src_port_id, pkt, pkts_num_leak_out + margin + pkts_num_dismiss_pfc - 1 + hysteresis + margin)
+            send_packet(self, src_port_id, pkt, pkts_num_leak_out + 2 * margin + pkts_num_dismiss_pfc - 1 + hysteresis)
             # send 1 packet to dst port 3, triggering PFC
             pkt = simple_tcp_packet(pktlen=default_packet_length,
                                     eth_dst=router_mac if router_mac != '' else dst_port_3_mac,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Originally we had a margin but in some cases, the test can still fail at a very low probability
So we need to enlarge it to make it safer.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
