### PR TITLE
[platform/sfp] Add test cases for SFP error status

### DIFF
--- a/tests/common/helpers/platform_api/sfp.py
+++ b/tests/common/helpers/platform_api/sfp.py
@@ -31,6 +31,10 @@ def get_presence(conn, index):
     return sfp_api(conn, index, 'get_presence')
 
 
+def get_error_description(conn, index):
+    return sfp_api(conn, index, 'get_error_description')
+
+
 def get_model(conn, index):
     return sfp_api(conn, index, 'get_model')
 

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -181,6 +181,14 @@ class TestSfpApi(PlatformApiTestBase):
                     self.expect(presence is True, "Transceiver {} is not present".format(i))
         self.assert_expectations()
 
+    def test_get_error_description(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+        for i in self.candidate_sfp:
+            error_description = sfp.get_error_description(platform_api_conn, i)
+            if self.expect(error_description is not None, "Unable to retrieve transceiver {} error description".format(i)):
+                if self.expect(isinstance(error_description, str) or isinstance(error_description, unicode), "Transceiver {} error description appears incorrect".format(i)):
+                    self.expect(error_description == "OK", "Transceiver {} is not present".format(i))
+        self.assert_expectations()
+
     def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         for i in self.candidate_sfp:
             model = sfp.get_model(platform_api_conn, i)

--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -43,21 +43,12 @@ def test_check_sfputil_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostn
         assert intf in parsed_presence, "Interface is not in output of '{}'".format(cmd_sfp_presence)
         assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
-@pytest.fixture(params=["sudo sfputil show error-status", "sudo sfputil show error-status --fetch-from-hardware"])
-def cmd_sfp_error_status(request):
-    """
-    @summary: Return the command for fetching sfp error status
-    """
-    return request.param
-
-
+@pytest.mark.parametrize("cmd_sfp_error_status", ["sudo sfputil show error-status", "sudo sfputil show error-status --fetch-from-hardware"])
 def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, cmd_sfp_error_status):
     """
     @summary: Check SFP error status using 'sfputil show error-status'
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    global ans_host
-    ans_host = duthost
     portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
 
     logging.info("Check output of '{}'".format(cmd_sfp_error_status))

--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -43,6 +43,31 @@ def test_check_sfputil_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostn
         assert intf in parsed_presence, "Interface is not in output of '{}'".format(cmd_sfp_presence)
         assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
+@pytest.fixture(params=["sudo sfputil show error-status", "sudo sfputil show error-status --fetch-from-hardware"])
+def cmd_sfp_error_status(request):
+    """
+    @summary: Return the command for fetching sfp error status
+    """
+    return request.param
+
+
+def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, cmd_sfp_error_status):
+    """
+    @summary: Check SFP error status using 'sfputil show error-status'
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    global ans_host
+    ans_host = duthost
+    portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
+
+    logging.info("Check output of '{}'".format(cmd_sfp_error_status))
+    sfp_error_status = duthost.command(cmd_sfp_error_status)
+    parsed_presence = parse_output(sfp_error_status["stdout_lines"][2:])
+    for intf in dev_conn:
+        assert intf in parsed_presence, "Interface is not in output of '{}'".format(cmd_sfp_presence)
+        assert parsed_presence[intf] == "OK", "Interface error status is not 'OK'"
+
+
 def test_check_sfputil_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts):
     """
     @summary: Check SFP presence using 'sfputil show presence'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add test cases for SFP error status

Signed-off-by: Stephen Sun <stephens@nvidia.com>

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Add test cases for SFP error status
- Add test cases for sfputil show error-status
- Add platform test for SFP.get_error_description()

#### How did you do it?

#### How did you verify/test it?
Run regression test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
