### PR TITLE
Fix issues in dynamic buffer test

### DIFF
--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -2033,16 +2033,14 @@ def test_exceeding_headroom(duthosts, rand_one_dut_hostname, conn_graph_facts, p
                                                  'Failed to remove buffer profile .* with type BUFFER_PROFILE_TABLE',
                                                  'doTask: Failed to process buffer task, drop it'])
         logging.info('[Find out the longest cable length the port can support]')
-        cable_length = 300
+        cable_length = int(original_cable_len[:-1])
         cable_length_step = 128
-        never_applied = True
         while True:
             duthost.shell('config interface cable-length {} {}m'.format(port_to_test, cable_length))
             expected_profile = make_expected_profile_name(original_speed, '{}m'.format(cable_length))
             profile_applied = check_pg_profile(duthost, 'BUFFER_PG_TABLE:{}:3-4'.format(port_to_test), expected_profile, False)
             if not profile_applied:
                 break
-            never_applied = False
             logging.info('Cable length {} has been applied successfully'.format(cable_length))
             if cable_length > 2000:
                 pytest.skip("Not able to find the maximum headroom of port {} after cable length has been increased to 2km, skip the test".format(port_to_test))
@@ -2053,12 +2051,8 @@ def test_exceeding_headroom(duthosts, rand_one_dut_hostname, conn_graph_facts, p
         cable_length_upper = cable_length
         cable_length_step /= 2
         cable_length -= cable_length_step
-        if never_applied:
-            cable_length_lower = int(original_cable_len[:-1])
-        else:
-            cable_length_lower = cable_length
+        cable_length_lower = cable_length
         logging.info("Cable length {} can be applied but {} can't. Finding the exact maximum cable length".format(cable_length_lower, cable_length_upper))
-
         while True:
             cable_length = (cable_length_upper + cable_length_lower) / 2
             duthost.shell('config interface cable-length {} {}m'.format(port_to_test, cable_length))

--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -2624,9 +2624,10 @@ def mellanox_calculate_headroom_data(duthost, port_to_test):
     xon_value = 0
     headroom_size = 0
     speed_overhead = 0
+    pipeline_latency = PIPELINE_LATENCY
 
     if is_8lane:
-        PIPELINE_LATENCY = PIPELINE_LATENCY * 2 - 1024
+        pipeline_latency = PIPELINE_LATENCY * 2 - 1024
         speed_overhead = port_mtu
     else:
         speed_overhead = 0
@@ -2652,7 +2653,7 @@ def mellanox_calculate_headroom_data(duthost, port_to_test):
     # Calculate the xoff and xon and then round up at 1024 bytes
     xoff_value = LOSSLESS_MTU + propagation_delay * cell_occupancy
     xoff_value = math.ceil(xoff_value / 1024) * 1024
-    xon_value = PIPELINE_LATENCY
+    xon_value = pipeline_latency
     xon_value = math.ceil(xon_value / 1024) * 1024
 
     if shp_enabled:

--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -2035,12 +2035,14 @@ def test_exceeding_headroom(duthosts, rand_one_dut_hostname, conn_graph_facts, p
         logging.info('[Find out the longest cable length the port can support]')
         cable_length = 300
         cable_length_step = 128
+        never_applied = True
         while True:
             duthost.shell('config interface cable-length {} {}m'.format(port_to_test, cable_length))
             expected_profile = make_expected_profile_name(original_speed, '{}m'.format(cable_length))
             profile_applied = check_pg_profile(duthost, 'BUFFER_PG_TABLE:{}:3-4'.format(port_to_test), expected_profile, False)
             if not profile_applied:
                 break
+            never_applied = False
             logging.info('Cable length {} has been applied successfully'.format(cable_length))
             if cable_length > 2000:
                 pytest.skip("Not able to find the maximum headroom of port {} after cable length has been increased to 2km, skip the test".format(port_to_test))
@@ -2051,8 +2053,12 @@ def test_exceeding_headroom(duthosts, rand_one_dut_hostname, conn_graph_facts, p
         cable_length_upper = cable_length
         cable_length_step /= 2
         cable_length -= cable_length_step
-        cable_length_lower = cable_length
+        if never_applied:
+            cable_length_lower = int(original_cable_len[:-1])
+        else:
+            cable_length_lower = cable_length
         logging.info("Cable length {} can be applied but {} can't. Finding the exact maximum cable length".format(cable_length_lower, cable_length_upper))
+
         while True:
             cable_length = (cable_length_upper + cable_length_lower) / 2
             duthost.shell('config interface cable-length {} {}m'.format(port_to_test, cable_length))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix issues:
 - wrong headroom calculated for 400G port due to global value updated every time
 - unable to find the lower bound in exceeding headroom test in case it has never been applied

Signed-off-by: Stephen Sun <stephens@nvidia.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix issues.

#### How did you do it?
1. Wrong headroom calculated for 400G port due to global value updated every time
   A factor in a global variable for calculating headroom is updated every time it is referenced, which causes wrong headroom calculated from the second time.
   Fix: should use a local copy when updating it.

2. Unable to find the lower bound in exceeding headroom test in case it has never been applied
   There is a logic to find the accurate cable length that can be applied in test_exceeding_headroom via using binary search.
   The initial lower bound is the cable length that has been applied successfully
   To fix the issue, we should always take the original cable length as the initial lower bound

#### How did you verify/test it?
Run regression test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
