### PR TITLE
Adjust platform API test for SN2201

### DIFF
--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -427,6 +427,10 @@ class TestChassisApi(PlatformApiTestBase):
 
         if duthost.facts.get("chassis"):
             expected_num_sfps = len(duthost.facts.get("chassis").get('sfps'))
+            if duthost.facts.get("platform") == 'x86_64-nvidia_sn2201-r0':
+                # On SN2201, there are 48 RJ45 ports which are also counted in SFP object lists
+                # So we need to adjust test case accordingly
+                expected_num_sfps += 48
             pytest_assert(num_sfps == expected_num_sfps,
                           "Number of sfps ({}) does not match expected number ({})"
                           .format(num_sfps, expected_num_sfps))

--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -51,6 +51,11 @@ x86_64-mlnx_msn2700-r0:
     greater_timeout: 100
     too_big_timeout: 66000
 
+x86_64-nvidia_sn2201-r0
+  default:
+    greater_timeout: 100
+    too_big_timeout: 66000
+
 # Dell watchdog
 x86_64-dell.*:
   default:


### PR DESCRIPTION
1. RJ45 ports are also implemented by SFP API, which affects platform API `get_num_sfps` test.
   Test case needs to be adjusted accordingly
2. Supply default watchdog time definition for SN2201

Signed-off-by: Stephen Sun <stephens@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
