### PR TITLE
[QoS] Verify the additional lossless queues and PGs in QoS test in dual ToR scenario

### DIFF
--- a/tests/qos/args/qos_sai_args.py
+++ b/tests/qos/args/qos_sai_args.py
@@ -46,3 +46,10 @@ def add_qos_sai_args(parser):
         help="QoS SAI comma separated list of source ports. Test currently expects exactly 1 source port",
     )
 
+    qos_group.addoption(
+        "--qos_dual_tor",
+        action="store",
+        type=str2bool,
+        default=False,
+        help="Test QoS on dual ToR ports"
+    )

--- a/tests/qos/files/mellanox/qos_param_generator.py
+++ b/tests/qos/files/mellanox/qos_param_generator.py
@@ -1,7 +1,7 @@
 import math
 
 class QosParamMellanox(object):
-    def __init__(self, qos_params, asic_type, speed_cable_len, dutConfig, ingressLosslessProfile, ingressLossyProfile, egressLosslessProfile, egressLossyProfile, sharedHeadroomPoolSize):
+    def __init__(self, qos_params, asic_type, speed_cable_len, dutConfig, ingressLosslessProfile, ingressLossyProfile, egressLosslessProfile, egressLossyProfile, sharedHeadroomPoolSize, dualTor):
         asic_param_dic = {
             'spc1': {
                 'cell_size': 96,
@@ -16,7 +16,6 @@ class QosParamMellanox(object):
                 'headroom_overhead': 64
             }
         }
-
         self.asic_type = asic_type
         self.cell_size = asic_param_dic[asic_type]['cell_size']
         self.headroom_overhead = asic_param_dic[asic_type]['headroom_overhead']
@@ -41,6 +40,7 @@ class QosParamMellanox(object):
         else:
             self.sharedHeadroomPoolSize = None
         self.dutConfig = dutConfig
+        self.dualTor = dualTor
 
         return
 
@@ -77,6 +77,8 @@ class QosParamMellanox(object):
         pkts_num_trig_ingr_drp = ingress_lossless_size + headroom
         if self.sharedHeadroomPoolSize:
             pkts_num_trig_ingr_drp += xoff
+            if self.dualTor:
+                pkts_num_trig_ingr_drp += 2 * xoff
         else:
             pkts_num_trig_ingr_drp -= self.headroom_overhead
         pkts_num_dismiss_pfc = ingress_lossless_size + 1
@@ -89,13 +91,11 @@ class QosParamMellanox(object):
             ingress_ports_list_shp = []
             occupancy_per_port = ingress_lossless_size
             self.qos_parameters['dst_port_id'] = testPortIds[0]
+            pgs_per_port = 2 if not self.dualTor else 4
             for i in range(1, ingress_ports_num_shp):
-                # for the first PG
-                pkts_num_trig_pfc_shp.append(occupancy_per_port + xon + hysteresis)
-                # for the second PG
-                occupancy_per_port /= 2
-                pkts_num_trig_pfc_shp.append(occupancy_per_port + xon + hysteresis)
-                occupancy_per_port /= 2
+                for j in range(pgs_per_port):
+                    pkts_num_trig_pfc_shp.append(occupancy_per_port + xon + hysteresis)
+                    occupancy_per_port /= 2
                 ingress_ports_list_shp.append(testPortIds[i])
             self.qos_parameters['pkts_num_trig_pfc_shp'] = pkts_num_trig_pfc_shp
             self.qos_parameters['src_port_ids'] = ingress_ports_list_shp
@@ -135,7 +135,7 @@ class QosParamMellanox(object):
             hdrm_pool_size['pkts_num_hdrm_partial'] = self.qos_parameters['pkts_num_hdrm_partial']
             hdrm_pool_size['dst_port_id'] = self.qos_parameters['dst_port_id']
             hdrm_pool_size['src_port_ids'] = self.qos_parameters['src_port_ids']
-            hdrm_pool_size['pgs_num'] = 2 * len(self.qos_parameters['src_port_ids'])
+            hdrm_pool_size['pgs_num'] = (2 if not self.dualTor else 4) * len(self.qos_parameters['src_port_ids'])
             hdrm_pool_size['cell_size'] = self.cell_size
             hdrm_pool_size['margin'] = 3
         else:
@@ -149,6 +149,8 @@ class QosParamMellanox(object):
         xoff['pkts_num_margin'] = 3
         self.qos_params_mlnx[self.speed_cable_len]['xoff_1'].update(xoff)
         self.qos_params_mlnx[self.speed_cable_len]['xoff_2'].update(xoff)
+        self.qos_params_mlnx[self.speed_cable_len]['xoff_3'].update(xoff)
+        self.qos_params_mlnx[self.speed_cable_len]['xoff_4'].update(xoff)
 
         xon = {}
         xon['pkts_num_trig_pfc'] = pkts_num_trig_pfc
@@ -157,6 +159,8 @@ class QosParamMellanox(object):
         xon['pkts_num_margin'] = 3
         self.qos_params_mlnx['xon_1'].update(xon)
         self.qos_params_mlnx['xon_2'].update(xon)
+        self.qos_params_mlnx['xon_3'].update(xon)
+        self.qos_params_mlnx['xon_4'].update(xon)
 
         wm_pg_headroom = self.qos_params_mlnx[self.speed_cable_len]['wm_pg_headroom']
         wm_pg_headroom['pkts_num_trig_pfc'] = pkts_num_trig_pfc

--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -29,6 +29,14 @@ qos_params:
                     dscp: 4
                     ecn: 1
                     pg: 4
+                xoff_3:
+                    dscp: 2
+                    ecn: 1
+                    pg: 2
+                xoff_4:
+                    dscp: 6
+                    ecn: 1
+                    pg: 6
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
@@ -42,9 +50,9 @@ qos_params:
                     pkts_num_fill_min: 0
                     packet_size: 300
                 hdrm_pool_size:
-                    dscps: [3, 4]
+                    dscps: [3, 4, 2, 6]
                     ecn: 1
-                    pgs: [3, 4]
+                    pgs: [3, 4, 2, 6]
                     pkts_num_trig_pfc: 0
                     pkts_num_leak_out: 0
                     pkts_num_fill_min: 0
@@ -58,6 +66,16 @@ qos_params:
                 dscp: 4
                 ecn: 1
                 pg: 4
+                pkts_num_leak_out: 0
+            xon_3:
+                dscp: 2
+                ecn: 1
+                pg: 2
+                pkts_num_leak_out: 0
+            xon_4:
+                dscp: 6
+                ecn: 1
+                pg: 6
                 pkts_num_leak_out: 0
             ecn_1:
                 dscp: 8

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1140,14 +1140,23 @@ class QosSaiBase(QosBase):
             duthost = duthosts[rand_one_dut_hostname]
 
         dut_asic = duthost.asic_instance(enum_frontend_asic_index)
+        srcport = dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]]
+
+        if "dynamic" in self.isBufferInApplDb(dut_asic):
+            if self.isPortDualTor(dut_asic, srcport):
+                pgs = "2-4"
+            else:
+                pgs = "3-4"
+        else:
+            pgs = "3"
 
         yield self.__getBufferProfile(
             request,
             dut_asic,
             duthost.os_version,
             "BUFFER_PG_TABLE" if self.isBufferInApplDb(dut_asic) else "BUFFER_PG",
-            dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]],
-            "3-4"
+            srcport,
+            pgs
         )
 
     @pytest.fixture(scope='class', autouse=True)
@@ -1205,14 +1214,20 @@ class QosSaiBase(QosBase):
             duthost = duthosts[rand_one_dut_hostname]
 
         dut_asic = duthost.asic_instance(enum_frontend_asic_index)
+        srcport = dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]]
+
+        if self.isPortDualTor(dut_asic, srcport):
+            queues = "2-4"
+        else:
+            queues = "3-4"
 
         yield self.__getBufferProfile(
             request,
             dut_asic,
             duthost.os_version,
             "BUFFER_QUEUE_TABLE" if self.isBufferInApplDb(dut_asic) else "BUFFER_QUEUE",
-            dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]],
-            "3-4"
+            srcport,
+            queues
         )
 
     @pytest.fixture(scope='class', autouse=True)

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1142,13 +1142,10 @@ class QosSaiBase(QosBase):
         dut_asic = duthost.asic_instance(enum_frontend_asic_index)
         srcport = dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]]
 
-        if "dynamic" in self.isBufferInApplDb(dut_asic):
-            if self.isPortDualTor(dut_asic, srcport):
-                pgs = "2-4"
-            else:
-                pgs = "3-4"
+        if self.isPortDualTor(dut_asic, srcport):
+            pgs = "2-4"
         else:
-            pgs = "3"
+            pgs = "3-4"
 
         yield self.__getBufferProfile(
             request,

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1140,23 +1140,14 @@ class QosSaiBase(QosBase):
             duthost = duthosts[rand_one_dut_hostname]
 
         dut_asic = duthost.asic_instance(enum_frontend_asic_index)
-        srcport = dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]]
-
-        if "dynamic" in self.isBufferInApplDb(dut_asic):
-            if self.isPortDualTor(dut_asic, srcport):
-                pgs = "2-4"
-            else:
-                pgs = "3-4"
-        else:
-            pgs = "3"
 
         yield self.__getBufferProfile(
             request,
             dut_asic,
             duthost.os_version,
             "BUFFER_PG_TABLE" if self.isBufferInApplDb(dut_asic) else "BUFFER_PG",
-            srcport,
-            pgs
+            dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]],
+            "3-4"
         )
 
     @pytest.fixture(scope='class', autouse=True)
@@ -1214,20 +1205,14 @@ class QosSaiBase(QosBase):
             duthost = duthosts[rand_one_dut_hostname]
 
         dut_asic = duthost.asic_instance(enum_frontend_asic_index)
-        srcport = dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]]
-
-        if self.isPortDualTor(dut_asic, srcport):
-            queues = "2-4"
-        else:
-            queues = "3-4"
 
         yield self.__getBufferProfile(
             request,
             dut_asic,
             duthost.os_version,
             "BUFFER_QUEUE_TABLE" if self.isBufferInApplDb(dut_asic) else "BUFFER_QUEUE",
-            srcport,
-            queues
+            dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]],
+            "3-4"
         )
 
     @pytest.fixture(scope='class', autouse=True)

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -54,6 +54,7 @@ QUEUE_3 = 3
 QUEUE_4 = 4
 QUEUE_5 = 5
 QUEUE_6 = 6
+QUEUE_7 = 7
 PG_NUM  = 8
 QUEUE_NUM = 8
 
@@ -251,6 +252,8 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
         src_port_id = int(self.test_params['src_port_id'])
         src_port_ip = self.test_params['src_port_ip']
         src_port_mac = self.dataplane.get_mac(0, src_port_id)
+        dual_tor_scenario = self.test_params.get('dual_tor_scenario')
+        dual_tor = self.test_params.get('dual_tor')
         exp_ip_id = 101
         exp_ttl = 63
         pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
@@ -301,10 +304,17 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
 
                 cnt = 0
                 dscp_received = False
+                dropped_dscp_dualtor_normal_port = [2, 6]
+                need_to_drop_dscp_2_6 = (dual_tor_scenario and not dual_tor)
                 while not dscp_received:
                     result = self.dataplane.poll(device_number=0, port_number=dst_port_id, timeout=3)
                     if isinstance(result, self.dataplane.PollFailure):
+                        if need_to_drop_dscp_2_6 and dscp in dropped_dscp_dualtor_normal_port:
+                            break
                         self.fail("Expected packet was not received on port %d. Total received: %d.\n%s" % (dst_port_id, cnt, result.format()))
+                    if need_to_drop_dscp_2_6 and dscp in dropped_dscp_dualtor_normal_port:
+                        self.fail("Packet with DSCP %d is not dropped" % (dscp))
+
                     recv_pkt = scapy.Ether(result.packet)
                     cnt += 1
 
@@ -336,14 +346,27 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
             # So for the 64 pkts sent the mapping should be -> 58 queue 1,
             # and 1 for queue0, queue2, queue3, queue4, queue5, and queue6
             # Check results
+            # For dual ToR scenario,
+            # dscp  2 -> queue 2
+            # dscp  6 -> queue 6
+            # dscp 48 -> queue 7
+            # dscp  5 -> queue 1
             # LAG ports can have LACP packets on queue 0, hence using >= comparison
             assert(queue_results[QUEUE_0] >= 1 + queue_results_base[QUEUE_0])
-            assert(queue_results[QUEUE_1] == 58 + queue_results_base[QUEUE_1])
-            assert(queue_results[QUEUE_2] == 1 + queue_results_base[QUEUE_2])
             assert(queue_results[QUEUE_3] == 1 + queue_results_base[QUEUE_3])
             assert(queue_results[QUEUE_4] == 1 + queue_results_base[QUEUE_4])
             assert(queue_results[QUEUE_5] == 1 + queue_results_base[QUEUE_5])
-            assert(queue_results[QUEUE_6] == 1 + queue_results_base[QUEUE_6])
+            if dual_tor:
+                assert(queue_results[QUEUE_2] == 1 + queue_results_base[QUEUE_2])
+                assert(queue_results[QUEUE_6] == 1 + queue_results_base[QUEUE_6])
+            else:
+                assert(queue_results[QUEUE_2] == queue_results_base[QUEUE_2])
+                assert(queue_results[QUEUE_6] == queue_results_base[QUEUE_6])
+            if dual_tor_scenario:
+                assert(queue_results[QUEUE_1] == 57 + queue_results_base[QUEUE_1])
+                assert(queue_results[QUEUE_7] == 1 + queue_results_base[QUEUE_7])
+            else:
+                assert(queue_results[QUEUE_1] == 58 + queue_results_base[QUEUE_1])
 
         finally:
             print >> sys.stderr, "END OF TEST"

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -304,16 +304,10 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
 
                 cnt = 0
                 dscp_received = False
-                dropped_dscp_dualtor_normal_port = [2, 6]
-                need_to_drop_dscp_2_6 = False #(dual_tor_scenario and not dual_tor)
                 while not dscp_received:
                     result = self.dataplane.poll(device_number=0, port_number=dst_port_id, timeout=3)
                     if isinstance(result, self.dataplane.PollFailure):
-                        if need_to_drop_dscp_2_6 and dscp in dropped_dscp_dualtor_normal_port:
-                            break
                         self.fail("Expected packet was not received on port %d. Total received: %d.\n%s" % (dst_port_id, cnt, result.format()))
-                    if need_to_drop_dscp_2_6 and dscp in dropped_dscp_dualtor_normal_port:
-                        self.fail("Packet with DSCP %d is not dropped" % (dscp))
 
                     recv_pkt = scapy.Ether(result.packet)
                     cnt += 1

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -305,7 +305,7 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
                 cnt = 0
                 dscp_received = False
                 dropped_dscp_dualtor_normal_port = [2, 6]
-                need_to_drop_dscp_2_6 = (dual_tor_scenario and not dual_tor)
+                need_to_drop_dscp_2_6 = False #(dual_tor_scenario and not dual_tor)
                 while not dscp_received:
                     result = self.dataplane.poll(device_number=0, port_number=dst_port_id, timeout=3)
                     if isinstance(result, self.dataplane.PollFailure):
@@ -363,7 +363,10 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
                 assert(queue_results[QUEUE_2] == queue_results_base[QUEUE_2])
                 assert(queue_results[QUEUE_6] == queue_results_base[QUEUE_6])
             if dual_tor_scenario:
-                assert(queue_results[QUEUE_1] == 57 + queue_results_base[QUEUE_1])
+                if not dual_tor:
+                    assert(queue_results[QUEUE_1] == 59 + queue_results_base[QUEUE_1])
+                else:
+                    assert(queue_results[QUEUE_1] == 57 + queue_results_base[QUEUE_1])
                 assert(queue_results[QUEUE_7] == 1 + queue_results_base[QUEUE_7])
             else:
                 assert(queue_results[QUEUE_1] == 58 + queue_results_base[QUEUE_1])


### PR DESCRIPTION
Introduce a way to verify the additional lossless queues and PGs in the QoS test in the dual ToR scenario

1. Add a CLI option to specify whether it is to verify ports with or without additional lossless PGs and queues.
   It will collect all the dual ToR ports at the beginning of the test. If the option is on, the additional lossless PGs/queues will be verified in the corresponding tests
   The port information will always be collected regardless of whether the CLI option is fed because non-dual ToR ports must be used while the option is not fed, which means we need to understand the ports' role in any case.
   We use a Lua script to fetch such info because it is much faster than intensively using `sonic-db-cli`
2. Update the logic to fetch buffer profiles from BUFFER_QUEUE and BUFFER_PG table according to the CLI
3. Two additional profiles are introduced for verifying the additional lossless PGs/queues in XON and XOFF test if the CLI option is on
4. For the headroom pool test, all 4 DSCPs are passed to the PTF script as well as the CLI option. The additional DSCPs will be skipped by the PTF docker according to whether the ports are with additional lossless PGs/queues.
5. For the DSCP2queue mapping test, the CLI option is passed to the PTF script so that the latter is able to check the mapping according to the CLI option.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
