### PR TITLE
Optimize the logic to compare the routing entries between ASIC_DB and the prefixes pushed to DUT

### DIFF
--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -160,6 +160,7 @@ def exec_routes(duthost, prefixes, str_intf_nexthop, op):
 
     # Generate json file for routes
     generate_route_file(duthost, prefixes, str_intf_nexthop, route_file_dir, op)
+    logger.info('Route file generated and copied')
 
     # Check the number of routes in ASIC_DB
     start_num_route = count_routes(duthost)
@@ -176,36 +177,44 @@ def exec_routes(duthost, prefixes, str_intf_nexthop, op):
         pytest.fail('Operation {} not supported'.format(op))
     start_time = datetime.now()
 
+    logger.info('Before pushing route to swssconfig')
     # Apply routes with swssconfig
     result = duthost.shell('docker exec -i swss swssconfig /dev/stdin < {}'.format(route_file_dir),
                            module_ignore_errors=True)
     if result['rc'] != 0:
         pytest.fail('Failed to apply route configuration file: {}'.format(result['stderr']))
+    logger.info('All route entries have been pushed')
 
-    # Wait until the routes set/del applys to ASIC_DB
-    def _check_num_routes(expected_num_routes):
-        # Check the number of routes in ASIC_DB
-        return count_routes(duthost) == expected_num_routes
-
-    if not wait_until(route_timeout, 0.5, 0, _check_num_routes, expected_num_routes):
-        pytest.fail('failed to add routes within time limit')
+    total_delay = 0
+    actual_num_routes = count_routes(duthost)
+    while actual_num_routes != expected_num_routes:
+        diff = abs(expected_num_routes - actual_num_routes)
+        delay = max(diff / 5000, 1)
+        now = datetime.now()
+        total_delay = (now - start_time).total_seconds()
+        logger.info('Current {} expected {} delayed {} will delay {}'.format(actual_num_routes, expected_num_routes, total_delay, delay))
+        time.sleep(delay)
+        actual_num_routes = count_routes(duthost)
+        if total_delay >= route_timeout:
+            break
 
     # Record time when all routes show up in ASIC_DB
     end_time = datetime.now()
+    logger.info('All route entries have been installed in ASIC_DB in {} seconds'.format((end_time - start_time).total_seconds()))
 
     # Check route entries are correct
     asic_route_keys = duthost.shell('sonic-db-cli ASIC_DB eval "return redis.call(\'keys\', \'{}*\')" 0'\
         .format(ROUTE_TABLE_NAME), verbose=False)['stdout_lines']
-    asic_prefixes = []
-    for key in asic_route_keys:
-        json_obj = key[len(ROUTE_TABLE_NAME) + 1 : ]
-        asic_prefixes.append(json.loads(json_obj)['dest'])
+    table_name_length = len(ROUTE_TABLE_NAME)
+    asic_route_keys_set = set([re.search("\"dest\":\"([0-9a-f:/\.]*)\"", x[table_name_length:]).group(1) for x in asic_route_keys])
+    prefixes_set = set(prefixes)
+    diff = prefixes_set - asic_route_keys_set
     if op == 'SET':
-        assert all(prefix in asic_prefixes for prefix in prefixes)
+        if diff:
+            pytest.fail("The following entries have not been installed into ASIC {}".format(diff))
     elif op == 'DEL':
-        assert all(prefix not in asic_prefixes for prefix in prefixes)
-    else:
-        pytest.fail('Operation {} not supported'.format(op))
+        if diff != prefixes_set:
+            pytest.fail("The following entries have not been withdrawn from ASIC {}".format(prefixes_set - diff))
 
     # Retuen time used for set/del routes
     return (end_time - start_time).total_seconds()


### PR DESCRIPTION
By doing so the time consumed by the logic is reduced significantly for 100000 routing entries:
- IPv4: 20 minutes => 20 seconds
- IPv6: 22 minutes => 2 minutes

The idea is
1. to extract the prefixes from the output of the DUT in order to avoid using json.load for each routing entry
2. to use set instead of list to check difference. `O(n*n)` => `O(n*lg(n))`

Logs before
```
2022-06-06 03:50:10 test_route_perf.test_perf_add_remove_rou L0229 INFO   | IP route utilization before test start: Used: 6414, Available: 186352, Test count: 100000
2022-06-06 04:08:05 test_route_perf.test_perf_add_remove_rou L0244 INFO   | Time to set 100000 ipv4 routes is 69.45 seconds.
2022-06-06 04:12:46 test_route_perf.test_perf_add_remove_rou L0248 INFO   | Time to del 100000 ipv4 routes is 50.76 seconds.
PASSED                                                                                                                                            [ 50%]
2022-06-06 04:13:13 test_route_perf.test_perf_add_remove_rou L0229 INFO   | IP route utilization before test start: Used: 6416, Available: 186352, Test count: 100000
2022-06-06 04:32:59 test_route_perf.test_perf_add_remove_rou L0244 INFO   | Time to set 100000 ipv6 routes is 132.96 seconds.
2022-06-06 04:38:33 test_route_perf.test_perf_add_remove_rou L0248 INFO   | Time to del 100000 ipv6 routes is 52.06 seconds.
PASSED                                                                                                                                            [100%]
```

Logs after
```
2022-06-06 07:25:43 test_route_perf.exec_routes              L0163 INFO   | Route file generated and copied
2022-06-06 07:25:43 test_route_perf.exec_routes              L0180 INFO   | Before pushing route to swssconfig
2022-06-06 07:26:42 test_route_perf.exec_routes              L0186 INFO   | All route entries have been pushed
2022-06-06 07:26:50 test_route_perf.exec_routes              L0203 INFO   | All route entries have been installed in ASIC_DB in 66.122285 seconds
2022-06-06 07:27:04 test_route_perf.test_perf_add_remove_rou L0253 INFO   | Time to set 100000 ipv4 routes is 66.12 seconds.
2022-06-06 07:27:07 test_route_perf.exec_routes              L0163 INFO   | Route file generated and copied
2022-06-06 07:27:16 test_route_perf.exec_routes              L0180 INFO   | Before pushing route to swssconfig
2022-06-06 07:28:08 test_route_perf.exec_routes              L0186 INFO   | All route entries have been pushed
2022-06-06 07:28:09 test_route_perf.exec_routes              L0203 INFO   | All route entries have been installed in ASIC_DB in 52.581642 seconds
2022-06-06 07:28:09 test_route_perf.test_perf_add_remove_rou L0257 INFO   | Time to del 100000 ipv4 routes is 52.58 seconds.
PASSED                                                                                                                                            [ 50%]
2022-06-06 07:28:43 test_route_perf.exec_routes              L0163 INFO   | Route file generated and copied
2022-06-06 07:28:43 test_route_perf.exec_routes              L0180 INFO   | Before pushing route to swssconfig
2022-06-06 07:29:42 test_route_perf.exec_routes              L0186 INFO   | All route entries have been pushed
2022-06-06 07:30:44 test_route_perf.exec_routes              L0203 INFO   | All route entries have been installed in ASIC_DB in 121.220825 seconds
2022-06-06 07:31:54 test_route_perf.test_perf_add_remove_rou L0253 INFO   | Time to set 100000 ipv6 routes is 121.22 seconds.
2022-06-06 07:31:58 test_route_perf.exec_routes              L0163 INFO   | Route file generated and copied
2022-06-06 07:33:01 test_route_perf.exec_routes              L0180 INFO   | Before pushing route to swssconfig
2022-06-06 07:33:54 test_route_perf.exec_routes              L0186 INFO   | All route entries have been pushed
2022-06-06 07:33:54 test_route_perf.exec_routes              L0203 INFO   | All route entries have been installed in ASIC_DB in 53.888981 seconds
2022-06-06 07:33:55 test_route_perf.test_perf_add_remove_rou L0257 INFO   | Time to del 100000 ipv6 routes is 53.89 seconds.
PASSED                                                                                                                                            [100%]
```

Signed-off-by: Stephen Sun <stephens@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
