### PR TITLE
[Dynamic buffer calculation] Support CLI option to specify the port to test

### DIFF
--- a/tests/qos/args/buffer_args.py
+++ b/tests/qos/args/buffer_args.py
@@ -19,3 +19,11 @@ def add_dynamic_buffer_calculation_args(parser):
         default=False,
         help="Whether the shared headroom pool should be enabled before dynamic buffer calculation test",
     )
+
+    dynamic_buffer_calculation_group.addoption(
+        "--port_to_test",
+        action="store",
+        type=str,
+        default=None,
+        help="The port to test"
+    )


### PR DESCRIPTION
Support CLI option to specify the port to test

Signed-off-by: Stephen Sun <stephens@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
