### PR TITLE
PSU power threshold exceeding check

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -31,7 +31,7 @@ def get_dut_psu_line_pattern(dut):
     if "201811" in dut.os_version or "201911" in dut.os_version:
         psu_line_pattern = re.compile(r"PSU\s+(\d)+\s+(OK|NOT OK|NOT PRESENT)")
     elif dut.facts['platform'] == "x86_64-dellemc_z9332f_d1508-r0" or dut.facts['asic_type'] == "cisco-8000":
-        psu_line_pattern = re.compile(r"PSU\s+(\d+).*?(OK|NOT OK|NOT PRESENT)\s+(N/A)")
+        psu_line_pattern = re.compile(r"PSU\s+(\d+).*?(OK|NOT OK|NOT PRESENT|WARNING)\s+(N/A)")
     else:
         """
         Changed the pattern to match space (s+) and non-space (S+) only.
@@ -45,7 +45,7 @@ def get_dut_psu_line_pattern(dut):
             PSU 2  N/A      N/A               12.01           4.12        49.50  OK        green
 
         """
-        psu_line_pattern = re.compile(r"PSU\s+(\d+).*?(OK|NOT OK|NOT PRESENT)\s+(green|amber|red|off)")
+        psu_line_pattern = re.compile(r"PSU\s+(\d+).*?(OK|NOT OK|NOT PRESENT|WARNING)\s+(green|amber|red|off)")
     return psu_line_pattern
 
 

--- a/tests/platform_tests/mellanox/conftest.py
+++ b/tests/platform_tests/mellanox/conftest.py
@@ -1,5 +1,3 @@
-from tests.common.utilities import str2bool
-
 def pytest_addoption(parser):
     '''
         Adds option to Mellanox specific pytest

--- a/tests/platform_tests/mellanox/conftest.py
+++ b/tests/platform_tests/mellanox/conftest.py
@@ -14,8 +14,7 @@ def pytest_addoption(parser):
 
     mellanox_group.addoption(
         "--mock_any_testbed",
-        action="store",
-        type=str2bool,
-        default=True,
+        action="store_true",
+        default=False,
         help="Mock on testbeds which do not support PSU power thresholds",
     )

--- a/tests/platform_tests/mellanox/conftest.py
+++ b/tests/platform_tests/mellanox/conftest.py
@@ -15,6 +15,5 @@ def pytest_addoption(parser):
     mellanox_group.addoption(
         "--mock_any_testbed",
         action="store_true",
-        default=False,
         help="Mock on testbeds which do not support PSU power thresholds",
     )

--- a/tests/platform_tests/mellanox/conftest.py
+++ b/tests/platform_tests/mellanox/conftest.py
@@ -1,0 +1,21 @@
+from tests.common.utilities import str2bool
+
+def pytest_addoption(parser):
+    '''
+        Adds option to Mellanox specific pytest
+
+        Args:
+            parser: pytest parser object
+
+        Returns:
+            None
+    '''
+    mellanox_group = parser.getgroup("Mellanox test suite options")
+
+    mellanox_group.addoption(
+        "--mock_any_testbed",
+        action="store",
+        type=str2bool,
+        default=True,
+        help="Mock on testbeds which do not support PSU power thresholds",
+    )

--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -114,6 +114,12 @@ class MockerHelper:
     # LED related sys fs folder path.
     LED_PATH = '/var/run/hw-management/led/'
 
+    # Config path
+    CONFIG_PATH = '/var/run/hw-management/config/'
+
+    # Power path
+    POWER_PATH = '/var/run/hw-management/power/'
+
     # FAN number of DUT.
     FAN_NUM = 0
 
@@ -190,21 +196,26 @@ class MockerHelper:
         file_path = os.path.join(MockerHelper.LED_PATH, file_path)
         self.mock_value(file_path, value)
 
-    def mock_value(self, file_path, value):
+    def mock_value(self, file_path, value, force=False):
         """
         Unlink existing sys fs file and replace it with a new one. Write given value to the new file.
         :param file_path: Sys fs file path.
         :param value: Value to write to sys fs file.
+        :param force: Force mock even if the file does not exist.
         :return:
         """
         if file_path not in self.regular_file_list and file_path not in self.unlink_file_list:
             out = self.dut.stat(path=file_path)
+            exist = True
             if not out['stat']['exists']:
-                raise SysfsNotExistError('{} not exist'.format(file_path))
-            if out['stat']['islnk']:
+                if force:
+                    exist = False
+                else:
+                    raise SysfsNotExistError('{} not exist'.format(file_path))
+            if exist and out['stat']['islnk']:
                 self._unlink(file_path)
             else:
-                self._cache_file_value(file_path)
+                self._cache_file_value(file_path, force)
         self.dut.shell('echo \'{}\' > {}'.format(value, file_path))
 
     def read_thermal_value(self, file_path):
@@ -241,7 +252,7 @@ class MockerHelper:
         except Exception as e:
             assert 0, "Get content from %s failed, exception: %s" % (file_path, repr(e))
 
-    def _cache_file_value(self, file_path):
+    def _cache_file_value(self, file_path, may_nexist=False):
         """
         Cache file value for regular file.
         :param file_path: Regular file path.
@@ -252,7 +263,10 @@ class MockerHelper:
             value = output["stdout"]
             self.regular_file_list[file_path] = value.strip()
         except Exception as e:
-            assert 0, "Get content from %s failed, exception: %s" % (file_path, repr(e))
+            if may_nexist:
+                self.regular_file_list[file_path] = None
+            else:
+                assert 0, "Get content from %s failed, exception: %s" % (file_path, repr(e))
 
     def _unlink(self, file_path):
         """
@@ -282,7 +296,10 @@ class MockerHelper:
         failed_recover_files = {}
         for file_path, value in self.regular_file_list.items():
             try:
-                self.dut.shell('echo \'{}\' > {}'.format(value, file_path))
+                if value is None:
+                    self.dut.shell('rm {}'.format(file_path))
+                else:
+                    self.dut.shell('echo \'{}\' > {}'.format(value, file_path))
             except Exception as e:
                 # Catch any exception for later retry
                 failed_recover_files[file_path] = value
@@ -1192,3 +1209,67 @@ class CpuThermalMocker(object):
 
     def get_cpu_cooling_state(self):
         return int(self.mock_helper.read_value(self.CPU_COOLING_STATE_FILE))
+
+
+@mocker('PsuPowerThresholdMocker')
+class PsuPowerThresholdMocker(object):
+    PORT_AMBIENT_TEMP = '/var/run/hw-management/thermal/port_amb'
+    FAN_AMBIENT_TEMP = '/var/run/hw-management/thermal/fan_amb'
+    AMBIENT_TEMP_CRITICAL_THRESHOLD = '/var/run/hw-management/config/amb_tmp_crit_limit'
+    AMBIENT_TEMP_WARNING_THRESHOLD = '/var/run/hw-management/config/amb_tmp_warn_limit'
+    PSU_POWER_SLOPE = '/var/run/hw-management/config/psu_power_slope'
+    PSU_POWER_CAPACITY = '/var/run/hw-management/config/psu{}_power_capacity'
+    PSU_POWER = '/var/run/hw-management/power/psu{}_power'
+
+    def __init__(self, dut):
+        self.mock_helper = MockerHelper(dut)
+
+    def deinit(self):
+        self.mock_helper.deinit()
+
+    def mock_power_threshold(self, number_psus):
+        self.mock_helper.mock_value(self.AMBIENT_TEMP_WARNING_THRESHOLD, 65000, True)
+        self.mock_helper.mock_value(self.AMBIENT_TEMP_CRITICAL_THRESHOLD, 75000, True)
+        self.mock_helper.mock_value(self.PSU_POWER_SLOPE, 2000, True)
+
+        max_power = None
+        for i in range(number_psus):
+            if not max_power:
+                power = int(self.mock_helper.read_value(self.PSU_POWER.format(i + 1)))
+                # Round up to 100 watt and then double it to avoid noise when power fluctuate
+                max_power = int(round(power/100000000.0)) * 100000000 * 2
+            self.mock_helper.mock_value(self.PSU_POWER_CAPACITY.format(i + 1), max_power, True)
+
+        # Also mock ambient temperatures
+        self.mock_helper.mock_value(self.PORT_AMBIENT_TEMP, self.read_port_ambient_thermal())
+        self.mock_helper.mock_value(self.FAN_AMBIENT_TEMP, self.read_fan_ambient_thermal())
+
+    def mock_psu_power(self, psu, power):
+        self.mock_helper.mock_value(self.PSU_POWER.format(psu), int(power))
+
+    def mock_fan_ambient_thermal(self, temperature):
+        self.mock_helper.mock_value(self.FAN_AMBIENT_TEMP, int(temperature))
+
+    def mock_port_ambient_thermal(self, temperature):
+        self.mock_helper.mock_value(self.PORT_AMBIENT_TEMP, int(temperature))
+
+    def read_psu_power_threshold(self, psu):
+        return int(self.mock_helper.read_value(self.PSU_POWER_CAPACITY.format(psu)))
+
+    def read_psu_power_slope(self):
+        return int(self.mock_helper.read_value(self.PSU_POWER_SLOPE))
+
+    def read_psu_power(self, psu):
+        return int(self.mock_helper.read_value(self.PSU_POWER.format(psu)))
+
+    def read_ambient_temp_critical_threshold(self):
+        return int(self.mock_helper.read_value(self.AMBIENT_TEMP_CRITICAL_THRESHOLD))
+
+    def read_ambient_temp_warning_threshold(self):
+        return int(self.mock_helper.read_value(self.AMBIENT_TEMP_WARNING_THRESHOLD))
+
+    def read_port_ambient_thermal(self):
+        return int(self.mock_helper.read_value(self.PORT_AMBIENT_TEMP))
+
+    def read_fan_ambient_thermal(self):
+        return int(self.mock_helper.read_value(self.FAN_AMBIENT_TEMP))

--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -297,7 +297,7 @@ class MockerHelper:
         for file_path, value in self.regular_file_list.items():
             try:
                 if value is None:
-                    self.dut.shell('rm {}'.format(file_path))
+                    self.dut.shell('rm -f {}'.format(file_path))
                 else:
                     self.dut.shell('echo \'{}\' > {}'.format(value, file_path))
             except Exception as e:

--- a/tests/platform_tests/mellanox/test_psu_power_threshold.py
+++ b/tests/platform_tests/mellanox/test_psu_power_threshold.py
@@ -238,8 +238,8 @@ def test_psu_power_threshold(request, duthosts, rand_one_dut_hostname, mock_powe
         # 2.1 Mock ambient temperature sensors
         power_warning_threshold, power_critical_threshold = \
             _update_ambient_sensors_and_check_db(psu_index,
-                                                 ambient_warning_threshold + (ambient_critical_threshold - ambient_warning_threshold)/2,
-                                                 ambient_critical_threshold,
+                                                 ambient_critical_threshold + 5000,
+                                                 ambient_critical_threshold + 1000,
                                                  power,
                                                  False)
         # Prepare for log analyzer

--- a/tests/platform_tests/mellanox/test_psu_power_threshold.py
+++ b/tests/platform_tests/mellanox/test_psu_power_threshold.py
@@ -77,12 +77,12 @@ def check_log_analyzer(loganalyzer, marker):
 
 @pytest.mark.disable_loganalyzer
 def test_psu_power_threshold(request, duthosts, rand_one_dut_hostname, mock_power_threshold):
-    def _check_psu_info_in_db(psu_index, power, power_threshold, power_critical_threshold, power_overload):
+    def _check_psu_info_in_db(psu_index, power, power_warning_threshold, power_critical_threshold, power_overload):
         psuname = 'PSU {}'.format(psu_index)
-        command_check_psu_db = 'sonic-db-cli STATE_DB hmget "PSU_INFO|{}" power power_threshold power_critical_threshold power_overload'.format(psuname)
+        command_check_psu_db = 'sonic-db-cli STATE_DB hmget "PSU_INFO|{}" power power_warning_threshold power_critical_threshold power_overload'.format(psuname)
         output = duthost.shell(command_check_psu_db)['stdout'].split()
         if int(float(output[0])) != power/1000000 \
-           or int(float(output[1])) != power_threshold/1000000 \
+           or int(float(output[1])) != power_warning_threshold/1000000 \
            or int(float(output[2])) != power_critical_threshold/1000000 \
            or output[3] != str(power_overload):
             return False

--- a/tests/platform_tests/mellanox/test_psu_power_threshold.py
+++ b/tests/platform_tests/mellanox/test_psu_power_threshold.py
@@ -1,0 +1,293 @@
+import logging
+import operator
+import pytest
+import random
+from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
+from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.mellanox_data import get_platform_data
+from tests.common.utilities import wait_until
+from tests.platform_tests.thermal_control_test_helper import *
+from mellanox_thermal_control_test_helper import MockerHelper, PsuPowerThresholdMocker
+from tabulate import tabulate
+import re
+
+pytestmark = [
+    pytest.mark.asic('mellanox'),
+    pytest.mark.topology('any')
+]
+
+logger = logging.getLogger(__name__)
+
+mocker = None
+
+@pytest.fixture
+# We can not set it as module because mocker_factory is function scope
+def mock_power_threshold(request, duthosts, rand_one_dut_hostname, mocker_factory):
+    global mocker
+    psudaemon_restarted = False
+
+    duthost = duthosts[rand_one_dut_hostname]
+
+    MockPlatform = request.config.getoption("--mock_any_testbed")
+    mocker = mocker_factory(duthost, 'PsuPowerThresholdMocker')
+    if MockPlatform:
+        try:
+            if mocker.read_psu_power_threshold(1) or mock.read_psu_power_threshold(2):
+                logger.info('CLI option "--mock_any_testbed" ignored since PSU power threshold is supported')
+        except Exception as e:
+            pass
+
+        logger.info('Mocking the system to support PSU power threshold')
+        mocker.mock_power_threshold(2)
+
+        # Restart PSU daemon to take the mock stuff
+        logger.info('Restart PSU daemon to take mock PSU power threshold')
+        duthost.shell('docker exec -ti pmon supervisorctl restart psud')
+        psudaemon_restarted = True
+        time.sleep(2)
+
+    yield
+
+    logging.info('Clean all mock files')
+    mocker.deinit()
+
+    if psudaemon_restarted:
+        logger.info('Restore PSU daemon')
+        duthost.shell('docker exec -ti pmon supervisorctl restart psud')
+        time.sleep(2)
+
+
+def init_log_analyzer(duthost, marker, expected, ignored=None):
+    loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=marker)
+    marker = loganalyzer.init()
+
+    loganalyzer.load_common_config()
+    loganalyzer.expect_regex = []
+    loganalyzer.expect_regex.extend(expected)
+    if ignored:
+        loganalyzer.ignore_regex.extend(ignored)
+
+    return loganalyzer, marker
+
+
+def check_log_analyzer(loganalyzer, marker):
+    loganalyzer.analyze(marker)
+    return loganalyzer
+
+
+@pytest.mark.disable_loganalyzer
+def test_psu_power_threshold(request, duthosts, rand_one_dut_hostname, mock_power_threshold):
+    def _check_psu_info_in_db(psu_index, power, power_threshold, power_critical_threshold, power_overload):
+        psuname = 'PSU {}'.format(psu_index)
+        command_check_psu_db = 'sonic-db-cli STATE_DB hmget "PSU_INFO|{}" power power_threshold power_critical_threshold power_overload'.format(psuname)
+        output = duthost.shell(command_check_psu_db)['stdout'].split()
+        if int(float(output[0])) != power/1000000 \
+           or int(float(output[1])) != power_threshold/1000000 \
+           or int(float(output[2])) != power_critical_threshold/1000000 \
+           or output[3] != str(power_overload):
+            return False
+
+        command_check_system_health_db = 'sonic-db-cli STATE_DB hgetall SYSTEM_HEALTH_INFO'
+        output = duthost.shell(command_check_system_health_db)['stdout']
+        system_health_dict = eval(output)
+        if power_overload:
+            if 'Not OK' not in system_health_dict['summary'] \
+               or 'exceeds threshold' not in system_health_dict[psuname]:
+                return False
+        else:
+            if system_health_dict['summary'] != 'OK':
+                return False
+
+        return True
+
+    def _calculate_psu_power_threshold(ambient_threshold, port_ambient, fan_ambient):
+        ambient_temperature = min(port_ambient, fan_ambient)
+        if ambient_temperature <= ambient_threshold:
+            return power_capacity
+
+        return power_capacity - slope * (ambient_temperature - ambient_threshold)
+
+    global mocker
+
+    duthost = duthosts[rand_one_dut_hostname]
+
+    psu_index = 1
+    power_capacity = mocker.read_psu_power_threshold(psu_index)
+    slope = mocker.read_psu_power_slope()
+    power = mocker.read_psu_power(psu_index)
+    ambient_critical_threshold = mocker.read_ambient_temp_critical_threshold()
+    ambient_warning_threshold = mocker.read_ambient_temp_warning_threshold()
+    fan_ambient = mocker.read_fan_ambient_thermal()
+    port_ambient = mocker.read_port_ambient_thermal()
+
+    if fan_ambient > ambient_warning_threshold or port_ambient > ambient_warning_threshold:
+        pytest.fail('Fan ambient temperature {} or port ambient temperature exceeds the ambient warning threshold'.format(fan_ambient, port_ambient))
+
+    if power > power_capacity:
+        pytest.fail('Current power {} exceeds maximum power capacity {}'.format(power, power_capacity))
+
+    # Ignore some possible errors
+    loganalyzer, marker = init_log_analyzer(duthost,
+                                            'PSU power exceeding test',
+                                            [],
+                                            ['Failed to read from file {}'.format(PsuPowerThresholdMocker.PORT_AMBIENT_TEMP),
+                                             'Failed to read from file {}'.format(PsuPowerThresholdMocker.FAN_AMBIENT_TEMP)])
+
+    # Mock the power as well.
+    # This is to make sure the power will be a fixed value because it can flucuate if it was read from a sensor.
+    logger.info('Mock PSU power to {} which is in normal range'.format(power/1000000)) 
+    mocker.mock_psu_power(psu_index, power)
+
+    # 1. Mock power to range (warning, critical)
+    # 1.2 Mock ambient temperature sensors
+    port_ambient_mock = ambient_warning_threshold + (ambient_critical_threshold - ambient_warning_threshold)/2
+    fan_ambient_mock = ambient_critical_threshold
+    power_critical_threshold = _calculate_psu_power_threshold(ambient_critical_threshold, port_ambient_mock, fan_ambient_mock)
+    power_warning_threshold = _calculate_psu_power_threshold(ambient_warning_threshold, port_ambient_mock, fan_ambient_mock)
+
+    logger.info('Mock ambient temperature sensors (fan {} port {}) and check the thresholds'.format(
+        port_ambient_mock/1000,
+        fan_ambient_mock/1000))
+    mocker.mock_port_ambient_thermal(port_ambient_mock)
+    mocker.mock_fan_ambient_thermal(fan_ambient_mock)
+    # Check whether thresholds are updated
+    assert wait_until(10,
+                      2,
+                      0,
+                      _check_psu_info_in_db,
+                      psu_index,
+                      power,
+                      power_warning_threshold,
+                      power_critical_threshold,
+                      False)
+
+    # 1.2 Mock the power
+    power = power_warning_threshold
+    logger.info('Mock PSU power to {} which is in the range between warning {} and critical {} thresholds'.format(
+        power/1000000,
+        power_warning_threshold/1000000,
+        power_critical_threshold/1000000))
+    mocker.mock_psu_power(psu_index, power)
+    assert wait_until(10,
+                      2,
+                      0,
+                      _check_psu_info_in_db,
+                      psu_index,
+                      power,
+                      power_warning_threshold,
+                      power_critical_threshold,
+                      False)
+
+    # 2. Mock power to range (critical, )
+    # 2.1 Mock ambient temperature sensors
+    port_ambient_mock = ambient_critical_threshold + 1000
+    fan_ambient_mock = ambient_critical_threshold + 5000
+    power_critical_threshold = _calculate_psu_power_threshold(ambient_critical_threshold, port_ambient_mock, fan_ambient_mock)
+    power_warning_threshold = _calculate_psu_power_threshold(ambient_warning_threshold, port_ambient_mock, fan_ambient_mock)
+
+    logger.info('Mock ambient temperature sensors (fan {} port {}) and check the thresholds'.format(
+        port_ambient_mock/1000,
+        fan_ambient_mock/1000))
+    mocker.mock_port_ambient_thermal(port_ambient_mock)
+    mocker.mock_fan_ambient_thermal(fan_ambient_mock)
+
+    # Check whether thresholds are updated
+    assert wait_until(10,
+                      2,
+                      0,
+                      _check_psu_info_in_db,
+                      psu_index,
+                      power,
+                      power_warning_threshold,
+                      power_critical_threshold,
+                      False)
+
+    # Prepare for log analyzer
+    check_log_analyzer(loganalyzer, marker)
+    loganalyzer, marker = init_log_analyzer(duthost,
+                                            'PSU power exceeds threshold',
+                                            ['PSU power warning: .* power .* exceeds critical threshold'])
+
+    # 2.2 Mock the power
+    power = power_critical_threshold + 1000000
+    logger.info('Mock PSU power to {} which is in greater than the critical threshold {}, make sure alarm is raised'.format(
+        power/1000000,
+        power_critical_threshold/1000000))
+    mocker.mock_psu_power(psu_index, power)
+    assert wait_until(80,
+                      10,
+                      0,
+                      _check_psu_info_in_db,
+                      psu_index,
+                      power,
+                      power_warning_threshold,
+                      power_critical_threshold,
+                      True)
+
+    # Check whether the expected message is found
+    check_log_analyzer(loganalyzer, marker)
+    loganalyzer, marker = init_log_analyzer(duthost, 'PSU power exceeding threshold', [])
+
+    # 3. Mock power to range (warning, critical)
+    power = power_critical_threshold - 1000000
+    logger.info('Mock PSU power to {} which is in the range the between warning {} and the critical {} thresholds, make sure alarm remains'.format(
+        power/1000000,
+        power_warning_threshold/1000000,
+        power_critical_threshold/1000000))
+    mocker.mock_psu_power(psu_index, power)
+    assert wait_until(10,
+                      2,
+                      0,
+                      _check_psu_info_in_db,
+                      psu_index,
+                      power,
+                      power_warning_threshold,
+                      power_critical_threshold,
+                      True)
+
+    # 4. Mock power to range (, warning)
+    # 4.1 Mock ambient temperature sensors
+    port_ambient_mock = ambient_critical_threshold + 1000
+    fan_ambient_mock = ambient_warning_threshold + (ambient_critical_threshold - ambient_warning_threshold)/2
+    power_critical_threshold = _calculate_psu_power_threshold(ambient_critical_threshold, port_ambient_mock, fan_ambient_mock)
+    power_warning_threshold = _calculate_psu_power_threshold(ambient_warning_threshold, port_ambient_mock, fan_ambient_mock)
+
+    logger.info('Mock ambient temperature sensors (fan {} port {}) and check the thresholds'.format(
+        port_ambient_mock/1000,
+        fan_ambient_mock/1000))
+    mocker.mock_port_ambient_thermal(port_ambient_mock)
+    mocker.mock_fan_ambient_thermal(fan_ambient_mock)
+    # Check whether thresholds are updated
+    assert wait_until(10,
+                      2,
+                      0,
+                      _check_psu_info_in_db,
+                      psu_index,
+                      power,
+                      power_warning_threshold,
+                      power_critical_threshold,
+                      True)
+
+    # Prepare log analyzer
+    check_log_analyzer(loganalyzer, marker)
+    loganalyzer, marker = init_log_analyzer(duthost,
+                                            'PSU power become back to normal',
+                                            ['PSU power warning cleared: .* power .* is back to normal'])
+
+    # 4.2 Mock power
+    power = power_warning_threshold - 1000000
+    logger.info('Mock PSU power to {} which is less than the warning threshold {}, make sure alarm is cleared'.format(
+        power/1000000,
+        power_warning_threshold/1000000))
+    mocker.mock_psu_power(psu_index, power)
+    assert wait_until(80,
+                      10,
+                      0,
+                      _check_psu_info_in_db,
+                      psu_index,
+                      power,
+                      power_warning_threshold,
+                      power_critical_threshold,
+                      False)
+
+    check_log_analyzer(loganalyzer, marker)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Support test case for PSU power threshold exceeding check.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
1. Implement the regression test case of PSU power threshold exceeding check.
   It can be done on a per vendor/platform basis only because the way to trigger PSU power threshold exceeding varies among vendors and platforms.
2. Support parsing `WARNING` state in the output of `show platform psustatus`

#### How did you do it?
We implement the test as a mock test because
- It's not able to meet the conditions to trigger the PSU power to exceed its threshold in any regression test bed, (which requires 100% utilization of throughput and high power-consumption xSFP modules
- PSU power threshold exceeding checking is not supported on all testbeds. If we would like to run the test on a test bed which does not physically support it, we also need to mock it.

#### How did you verify/test it?

Manually test and run regression test.

#### Any platform specific information?

Mellanox platforms only.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
